### PR TITLE
Add Phase 1 polish and Phase 2 bulk creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ GITHUB_TOKEN=
 GITHUB_OWNER=
 GITHUB_REPO=
 
+# Branch to create issues from. Defaults to repo default branch if not set.
+OKFFS_BASE_BRANCH=main
+
 # Optional defaults applied to every new issue
 OKFFS_PROMPT_METADATA=true
 OKFFS_DEFAULT_ASSIGNEES=your-github-username

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ instructions
 .claude/settings.json
 .claude/settings.local.json
 
+# Local MCP config (contains machine-specific paths)
+.mcp.json
+
 # Editor/IDE
 .vscode/
 .idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 src/
 .env
 .env.example
+.mcp.json
 .github/
 .githooks/
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,17 +36,23 @@ Guidance for Claude Code when working in this repository.
 ### Phase 1 — Core MCP server ✓ Complete
 - TypeScript MCP server scaffolded.
 - PAT auth via `.env` (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`).
-- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`.
-- `create_issue` auto-creates a branch, embeds the branch name in the issue body, and surfaces default assignees/labels from `.env` (shown as `(default)` in output).
+- `.env` is loaded automatically via `dotenv` from `process.cwd()` — no `--env-file` flag needed in `.mcp.json`.
+- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`.
+- `create_issue` auto-creates a branch, embeds the branch name in the issue body, and surfaces default assignees/labels from `.env` (shown as `(default)` in output). Infers labels automatically; merges inferred labels with `OKFFS_DEFAULT_LABELS`. Supports optional `milestone`.
 - `list_issues` returns each issue with its issue URL and inferred branch URL.
+- `get_issue` fetches full issue details — title, body, status, branch, assignees, labels.
+- `comment_issue` posts a comment to an issue. Use after committing to log what was done.
 - `close_issue` closes the issue and posts a comment noting the branch remains open (branch name extracted from the embedded `**Branch:**` line).
 - `delete_issue` closes an issue and deletes its branch. Two-step: call once for a warning, re-call with `confirmed: true` to proceed. Posts a comment to the issue before acting.
 - `delete_branch` deletes a branch and closes its issue (issue number parsed from branch name prefix). Same two-step confirmation pattern.
-- Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`.
+- Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`.
+- `OKFFS_BASE_BRANCH` — set to override the base branch for new issue branches (skips the GitHub API call). Defaults to the repo's default branch.
 
-### Phase 2 — Bulk creation
+### Phase 2 — Bulk creation ✓ Complete
 - `create_issues_from_list` tool.
-- Accepts a markdown task list; creates all issues + branches in one shot.
+- Accepts a list of tasks; creates all issues + branches in one shot.
+- Two-step confirmation: call once to preview, re-call with `confirmed: true` to proceed.
+- Per-task `labels`, `assignees`, and `milestone` supported; labels merged with `OKFFS_DEFAULT_LABELS`.
 - Auto-generates branch names from issue number + title slug.
 
 ### Phase 3 — Claude.ai bridge
@@ -71,7 +77,8 @@ Guidance for Claude Code when working in this repository.
 ## Local setup
 
 - `.env` holds the GitHub PAT (`GITHUB_TOKEN`) with `repo` + `project` scopes. It is git-ignored — see [.env.example](.env.example).
-- Optional defaults applied to every new issue: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip).
+- `.env` is loaded automatically at startup via `dotenv` from `process.cwd()`. No `--env-file` flag required in `.mcp.json`.
+- Optional defaults applied to every new issue: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default branch).
 
 ## Codebase search
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This project is being built in phases. See [CLAUDE.md](CLAUDE.md) for the full r
 
 | Phase | Scope | Status |
 |------|-------|--------|
-| 1 | Core MCP server — `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch` | **Complete** |
-| 2 | Bulk creation — `create_issues_from_list` | Planned |
+| 1 | Core MCP server — `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue` | **Complete** |
+| 2 | Bulk creation — `create_issues_from_list` | **Complete** |
 | 3 | Claude.ai bridge — markdown paste format + `/push-to-github` | Planned |
 | 4 | Auto-close on merge — embed `Closes #N` in PR body | Planned |
 | 5 | GitHub Projects v2 (optional) | Planned |
@@ -81,15 +81,21 @@ Files excluded from the published package are listed in [.npmignore](.npmignore)
    ```env
    OKFFS_DEFAULT_ASSIGNEES=your-github-username
    OKFFS_DEFAULT_LABELS=feature,bug
-   OKFFS_PROMPT_METADATA=true   # set to false to hide the assignees/labels tip
+   OKFFS_PROMPT_METADATA=true        # set to false to hide the assignees/labels tip
+   OKFFS_BASE_BRANCH=main            # branch to create issues from; defaults to repo default branch
    ```
+
+   The `.env` file is loaded automatically from whichever directory the MCP server starts in — no `--env-file` flag needed.
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `create_issue` | Creates a GitHub issue and a corresponding branch. Returns issue URL, number, and branch name. Applies `OKFFS_DEFAULT_ASSIGNEES` / `OKFFS_DEFAULT_LABELS` from `.env` when not supplied explicitly. |
+| `create_issue` | Creates a GitHub issue and a matching branch. Infers labels automatically; merges them with `OKFFS_DEFAULT_LABELS`. Supports optional `milestone`. |
+| `create_issues_from_list` | Creates multiple issues and branches from a task list in one shot. Confirms before acting. |
 | `list_issues` | Lists all open issues with their issue URL and branch URL. |
+| `get_issue` | Fetches full details of an issue — title, body, labels, assignees, branch, and status. |
+| `comment_issue` | Posts a comment to an issue. Useful for logging work done on a branch. |
 | `close_issue` | Closes a GitHub issue by number. Posts a comment noting the branch remains open. |
 | `delete_issue` | Closes an issue **and** deletes its matching branch. Destructive — requires `confirmed: true`. |
 | `delete_branch` | Deletes a branch **and** closes its matching issue. Destructive — requires `confirmed: true`. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "okffs",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "okffs",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "dotenv": "^17.4.2",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.2"
       },
@@ -729,6 +730,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "dotenv": "^17.4.2",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.2"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,4 +6,5 @@ export const config = {
   defaultLabels: process.env.OKFFS_DEFAULT_LABELS
     ? process.env.OKFFS_DEFAULT_LABELS.split(",").map((s) => s.trim())
     : [],
+  baseBranch: process.env.OKFFS_BASE_BRANCH || null,
 };

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,3 +1,5 @@
+import { config } from "./config.js";
+
 const BASE = "https://api.github.com";
 
 const token = process.env.GITHUB_TOKEN;
@@ -46,11 +48,12 @@ export async function createIssue(
   title: string,
   body: string,
   assignees?: string[],
-  labels?: string[]
+  labels?: string[],
+  milestone?: number
 ): Promise<{ number: number; html_url: string }> {
   return request(`/repos/${owner}/${repo}/issues`, {
     method: "POST",
-    body: JSON.stringify({ title, body, assignees, labels }),
+    body: JSON.stringify({ title, body, assignees, labels, ...(milestone !== undefined && { milestone }) }),
   });
 }
 
@@ -62,6 +65,7 @@ export async function updateIssueBody(issueNumber: number, body: string): Promis
 }
 
 export async function getDefaultBranch(): Promise<string> {
+  if (config.baseBranch) return config.baseBranch;
   const data = await request<{ default_branch: string }>(`/repos/${owner}/${repo}`);
   return data.default_branch;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -11,8 +13,11 @@ import * as listIssues from "./tools/list_issues.js";
 import * as closeIssue from "./tools/close_issue.js";
 import * as deleteIssue from "./tools/delete_issue.js";
 import * as deleteBranch from "./tools/delete_branch.js";
+import * as getIssue from "./tools/get_issue.js";
+import * as commentIssue from "./tools/comment_issue.js";
+import * as createIssuesFromList from "./tools/create_issues_from_list.js";
 
-const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch];
+const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList];
 
 const server = new Server(
   { name: "okffs", version: "0.0.1" },

--- a/src/tools/comment_issue.ts
+++ b/src/tools/comment_issue.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { addIssueComment, owner, repo } from "../github.js";
+
+export const name = "comment_issue";
+
+export const description =
+  "Post a comment to a GitHub issue. Use after committing to a working branch to log what was done.";
+
+export const inputSchema = z.object({
+  issue_number: z.number().int().positive(),
+  comment: z.string().describe("Comment body to post to the issue"),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  await addIssueComment(input.issue_number, input.comment);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Comment posted to issue #${input.issue_number}.\nhttps://github.com/${owner}/${repo}/issues/${input.issue_number}`,
+      },
+    ],
+  };
+}

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -5,20 +5,23 @@ import { config } from "../config.js";
 export const name = "create_issue";
 
 export const description =
-  "Create a GitHub issue and a corresponding branch. Returns the issue URL, issue number, and branch name.";
+  "Create a GitHub issue and automatically create a matching branch. Before calling this tool, infer appropriate labels from the issue title and description using GitHub's default labels: bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. Pass the inferred labels in the labels parameter unless the user has specified their own. Returns the issue URL, issue number, and branch name.";
 
 export const inputSchema = z.object({
   title: z.string().describe("Issue title"),
   description: z.string().describe("Issue body / description"),
   assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
   labels: z.array(z.string()).optional().describe("Labels to apply e.g. bug, feature"),
+  milestone: z.number().int().optional().describe("Milestone number to assign"),
 });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
   const resolvedAssignees = input.assignees ?? config.defaultAssignees;
-  const resolvedLabels = input.labels ?? config.defaultLabels;
+  const resolvedLabels = [
+    ...new Set([...(input.labels ?? []), ...config.defaultLabels])
+  ];
 
-  const issue = await createIssue(input.title, input.description, resolvedAssignees, resolvedLabels);
+  const issue = await createIssue(input.title, input.description, resolvedAssignees, resolvedLabels, input.milestone);
 
   const branchName = `${issue.number}-${slugify(input.title)}`;
 

--- a/src/tools/create_issues_from_list.ts
+++ b/src/tools/create_issues_from_list.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, slugify } from "../github.js";
+import { config } from "../config.js";
+
+export const name = "create_issues_from_list";
+
+export const description =
+  "Create multiple GitHub issues and matching branches from a list of tasks. Before calling this tool, infer appropriate labels for each task from its title and description using GitHub's default labels: bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. Pass inferred labels per task in the labels field unless the user has specified their own. Confirms before creating.";
+
+const taskSchema = z.object({
+  title: z.string().describe("Issue title"),
+  description: z.string().describe("Issue body / description"),
+  assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
+  labels: z.array(z.string()).optional().describe("Labels to apply to this issue"),
+  milestone: z.number().int().optional().describe("Milestone number to assign"),
+});
+
+export const inputSchema = z.object({
+  tasks: z.array(taskSchema).min(1).describe("List of issues to create"),
+  confirmed: z.boolean().optional().describe("Must be true to proceed with creation"),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  if (!input.confirmed) {
+    const preview = input.tasks
+      .map((t, i) => `${i + 1}. ${t.title}${t.labels?.length ? ` [${t.labels.join(", ")}]` : ""}`)
+      .join("\n");
+    return {
+      content: [{
+        type: "text" as const,
+        text: `About to create ${input.tasks.length} issue(s):\n\n${preview}\n\nRe-call create_issues_from_list with confirmed: true to proceed.`,
+      }],
+    };
+  }
+
+  const defaultBranch = await getDefaultBranch();
+  const ref = await getRef(defaultBranch);
+  const results: string[] = [];
+
+  for (const task of input.tasks) {
+    const resolvedAssignees = task.assignees ?? config.defaultAssignees;
+    const resolvedLabels = [
+      ...new Set([...(task.labels ?? []), ...config.defaultLabels])
+    ];
+
+    const issue = await createIssue(task.title, task.description, resolvedAssignees, resolvedLabels, task.milestone);
+    const branchName = `${issue.number}-${slugify(task.title)}`;
+    await createBranch(branchName, ref.object.sha);
+    const updatedBody = `${task.description}\n\n**Branch:** \`${branchName}\``;
+    await updateIssueBody(issue.number, updatedBody);
+
+    results.push(`#${issue.number} — ${task.title}\n  Branch: \`${branchName}\`\n  ${issue.html_url}`);
+  }
+
+  return {
+    content: [{ type: "text" as const, text: `Created ${results.length} issue(s):\n\n${results.join("\n\n")}` }],
+  };
+}

--- a/src/tools/get_issue.ts
+++ b/src/tools/get_issue.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { getIssue, extractBranchFromBody, owner, repo } from "../github.js";
+
+export const name = "get_issue";
+
+export const description =
+  "Fetch full details of a GitHub issue by number — title, body, labels, assignees, branch, and status.";
+
+export const inputSchema = z.object({
+  issue_number: z.number().int().positive(),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  const issue = await getIssue(input.issue_number) as {
+    number: number;
+    title: string;
+    html_url: string;
+    body: string | null;
+    state: string;
+    labels: Array<{ name: string }>;
+    assignees: Array<{ login: string }>;
+  };
+
+  const branch = extractBranchFromBody(issue.body);
+  const assignees = issue.assignees.map((a) => a.login).join(", ") || "none";
+  const labels = issue.labels.map((l) => l.name).join(", ") || "none";
+
+  const lines = [
+    `#${issue.number} — ${issue.title}`,
+    `Status: ${issue.state}`,
+    ...(branch ? [`Branch: ${branch}`] : []),
+    `Assignees: ${assignees}`,
+    `Labels: ${labels}`,
+    `URL: https://github.com/${owner}/${repo}/issues/${issue.number}`,
+    ``,
+    issue.body ?? "(no description)",
+  ];
+
+  return {
+    content: [{ type: "text" as const, text: lines.join("\n") }],
+  };
+}


### PR DESCRIPTION
- dotenv auto-loads .env from process.cwd() — no --env-file flag needed
- New tools: get_issue, comment_issue, create_issues_from_list
- OKFFS_BASE_BRANCH env var skips GitHub API call for default branch
- Labels now merged with OKFFS_DEFAULT_LABELS (deduped) instead of replaced
- create_issue and create_issues_from_list support optional milestone param
- .mcp.json added to .gitignore and .npmignore (machine-specific path)
- README and CLAUDE.md updated to reflect all changes