### PR TITLE
Close #22 - Fix broken link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 Closed: Test label fix. Verifying okffs default label and inferred label are both applied correctly
 
 **Branch:** `14-test-label-fix`
+TEST


### PR DESCRIPTION
## Summary
The quick start link in the README points to the wrong anchor

## Changes
- test

Closes #22