### PR TITLE
Release 0.1.5

### DIFF
--- a/.github/instructions/okffs.instructions.md
+++ b/.github/instructions/okffs.instructions.md
@@ -1,0 +1,77 @@
+---
+applyTo: "**"
+---
+
+# okffs — Copilot Instructions
+
+okffs is a TypeScript/Node.js Model Context Protocol (MCP) server that connects Claude Code to GitHub. It enables a full issue → branch → PR → merge → close workflow without leaving the IDE.
+
+## Architecture
+
+- `src/index.ts` — MCP server entry point, registers all tools via StdioServerTransport
+- `src/github.ts` — GitHub REST API client using PAT auth
+- `src/config.ts` — reads all OKFFS_* env vars
+- `src/docs.ts` — auto-updates local project docs on workflow events
+- `src/tools/` — one file per tool, each exports `name`, `description`, `inputSchema`, and `handler`
+
+## Tool patterns
+
+Every tool follows the same structure:
+```ts
+export const name = "tool_name";
+export const description = "...";
+export const inputSchema = z.object({ ... });
+export async function handler(input: z.infer<typeof inputSchema>) { ... }
+```
+
+Registered in `src/index.ts` via `server.tool(name, description, inputSchema.shape, handler)`.
+
+## Critical conventions
+
+**Destructive tools** (`delete_issue`, `delete_branch`) must:
+- Accept a `confirmed: boolean` optional parameter
+- Return a warning message without acting if `confirmed !== true`
+- Post a comment to the issue via `addIssueComment()` before acting
+- Then perform the destructive action
+
+**Branch naming:** `{issue-number}-{kebab-title-slug}` — issue number is always the prefix, used to link branches back to issues.
+
+**Branch extraction:** `extractBranchFromBody(issue.body)` parses the `**Branch:** \`name\`` line embedded by `create_issue`. All tools that need the branch name use this — never assume a branch name.
+
+**Issue number extraction from branch:** parse the numeric prefix e.g. `42-add-hero-section` → issue `42`.
+
+**PR convention:** title `Close #N - Issue title`, body always includes `Closes #N`.
+
+## Config flags
+
+All read from `src/config.ts`:
+- `config.autoPR` — if true, `close_issue` triggers `create_pull_request` automatically
+- `config.updateDocs` — if true, tools call `updateProjectDocs()` on workflow events
+- `config.excludeDocs` — array of filenames to skip during doc updates
+- `config.baseBranch` — override for base branch, falls back to repo default
+- `config.defaultAssignees` / `config.defaultLabels` — merged with per-call values
+
+## Doc auto-updates
+
+`updateProjectDocs(ctx)` in `src/docs.ts` writes to local files via `fs.writeFileSync`. It never commits — that's the user's responsibility.
+
+Files updated based on keyword matching:
+- `CHANGELOG.md` — always, on every trigger. Created if missing. Keep a Changelog format.
+- `CLAUDE.md` — convention/workflow/tool/config/architecture keywords
+- `SECURITY.md` — security/vulnerability/CVE keywords
+- `CONTRIBUTING.md` — convention/contributing/workflow keywords
+- `README.md` — intentionally excluded, maintained manually
+
+When `config.autoPR` is true, `close_issue` must NOT call `updateProjectDocs` — `create_pull_request` handles it to avoid duplicate entries.
+
+## GitHub API
+
+All calls go through `request<T>()` in `github.ts` which handles auth headers and 204 responses. Use this helper for all new API calls — never call `fetch` directly in tools.
+
+Pagination: always add `per_page=100` to list endpoints. For comments, use `sort=created&direction=desc` to get newest first.
+
+## Error handling
+
+- Non-destructive failures should warn and continue, never throw to the user
+- Destructive tool failures should surface clearly
+- `updateProjectDocs` failures always warn only — never block the main tool action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+### Fixed
+- fix & enhance: auto-PR flow improvements, CHANGELOG commit, branch push, and new workflow tools ([#38](https://github.com/2b9sa2owa/okffs/issues/38)) — Fixes and enhancements to the auto-PR flow plus a new commit_and_update tool.
+
+- create_pull_request now commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling.
+- close_issue returns a /clear tip and no longer triggers a PR on c...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,20 +39,21 @@ Guidance for Claude Code when working in this repository.
 - TypeScript MCP server scaffolded.
 - PAT auth via `.env` (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`).
 - `.env` is loaded automatically via `dotenv` from `process.cwd()` — no `--env-file` flag needed in `.mcp.json`.
-- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`.
-- `create_issue` auto-creates a branch, embeds the branch name in the issue body, applies default assignees/labels from `.env`, infers labels from title/description and merges with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, `milestone`. If a relationship is mentioned (blocked by, blocking, parent), automatically calls `link_issues` after creation.
+- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `create_pull_request`, `commit_and_update`.
+- `create_issue` auto-creates a branch, embeds the branch name in the issue body, applies default assignees/labels from `.env`, infers labels from title/description and merges with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, `milestone`. If a relationship is mentioned (blocked by, blocking, parent), automatically calls `link_issues` after creation. If `OKFFS_AUTO_PR=true`, pushes an empty init commit to the branch (capturing and restoring the current branch) and opens a draft PR immediately.
 - `create_issues_from_list` accepts a list of tasks and creates all issues + branches in one shot. Two-step confirmation. Per-task `labels`, `assignees`, and `milestone` supported.
 - `list_issues` returns each issue with its issue URL and inferred branch URL.
 - `get_issue` fetches full issue details — title, body, status, branch, assignees, labels.
 - `comment_issue` posts a comment to an issue. Use after committing to log what was done.
 - `link_issues` links two issues with a relationship — `blocked_by`, `blocking`, or `parent`. Stored in the issue body under a `## Relationships` section.
-- `close_issue` closes the issue. If `OKFFS_AUTO_PR=true`, automatically creates a PR instead of posting a branch-remains-open comment.
+- `close_issue` closes the issue and returns a tip suggesting the user runs `/clear` in Claude Code to reset context before the next issue. (Under `OKFFS_AUTO_PR=true` the draft PR already exists from `create_issue`, so no PR is created here.)
+- `commit_and_update` stages all changes, generates a conventional commit message from the diff (or the optional `hint`), commits, pushes to the current branch, and posts a rich progress comment to the linked issue.
 - `delete_issue` closes an issue and deletes its branch. Two-step: call once for a warning, re-call with `confirmed: true` to proceed. Posts a comment before acting.
 - `delete_branch` deletes a branch and closes its issue (issue number parsed from branch name prefix). Same two-step confirmation pattern. Posts a comment before acting.
 - Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`, `OKFFS_UPDATE_DOCS`, `OKFFS_AUTO_PR`.
 - `OKFFS_BASE_BRANCH` — branch to create new issue branches from. Defaults to the repo's default branch.
 - `OKFFS_UPDATE_DOCS` — set to `true` to auto-update local project docs (CHANGELOG.md, CLAUDE.md, SECURITY.md, CONTRIBUTING.md) on workflow events. Default `false`. README.md is intentionally excluded.
-- `OKFFS_AUTO_PR` — set to `true` to automatically create a PR when closing an issue. Default `false`.
+- `OKFFS_AUTO_PR` — set to `true` to open a draft PR when a new issue branch is created (via `create_issue`). Default `false`.
 
 ### Phase 2 — Bulk creation ✓ Complete
 
@@ -70,8 +71,10 @@ Guidance for Claude Code when working in this repository.
 ### Phase 4 — Auto-close on merge ✓ Complete
 
 - `create_pull_request` tool — reads the issue, commits on the branch, and issue comments to generate a PR title and body. Always includes `Closes #N`. Posts a summary comment back to the issue.
-- If `OKFFS_UPDATE_DOCS=true`, updates CHANGELOG before the PR is created so the change is included in the PR diff.
-- If `OKFFS_AUTO_PR=true`, `close_issue` automatically triggers `create_pull_request`.
+- If `OKFFS_UPDATE_DOCS=true`, updates CHANGELOG before the PR is created and commits it onto the branch (`git add CHANGELOG.md` + commit) so the change is included in the PR diff. A commit failure is logged with an `[okffs]` prefix and never blocks PR creation.
+- Before creating the PR, the branch is pushed to remote (`git push origin <branch>`). If the push fails, a comment is posted to the issue and the PR is not created.
+- `OKFFS_AUTO_PR` no longer triggers a PR on close — the draft PR is opened at branch-creation time by `create_issue`. To accept the draft PR immediately, `create_issue` first pushes an empty init commit so the branch diverges from base.
+- `commit_and_update` tool — stages all changes, generates a conventional commit message, commits, pushes to the current branch, and posts a rich progress comment to the linked issue.
 - GitHub natively closes the issue on merge via `Closes #N` — no webhook infrastructure needed.
 - Edge case: if the branch has no commits ahead of the base branch, a friendly comment is posted instead of erroring.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Guidance for Claude Code when working in this repository.
 - `comment_issue` posts a comment to an issue. Use after committing to log what was done.
 - `link_issues` links two issues with a relationship — `blocked_by`, `blocking`, or `parent`. Stored in the issue body under a `## Relationships` section.
 - `close_issue` closes the issue and returns a tip suggesting the user runs `/clear` in Claude Code to reset context before the next issue. (Under `OKFFS_AUTO_PR=true` the draft PR already exists from `create_issue`, so no PR is created here.)
-- `commit_and_update` stages all changes, generates a conventional commit message from the diff (or the optional `hint`), commits, pushes to the current branch, and posts a rich progress comment to the linked issue.
+- `commit_and_update` stages all changes, builds a commit message from the optional `hint` (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.
 - `delete_issue` closes an issue and deletes its branch. Two-step: call once for a warning, re-call with `confirmed: true` to proceed. Posts a comment before acting.
 - `delete_branch` deletes a branch and closes its issue (issue number parsed from branch name prefix). Same two-step confirmation pattern. Posts a comment before acting.
 - Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`, `OKFFS_UPDATE_DOCS`, `OKFFS_AUTO_PR`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project is being built in phases. See [CLAUDE.md](CLAUDE.md) for the full r
 | 1 | Core MCP server — `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues` | **Complete** |
 | 2 | Bulk creation — `create_issues_from_list` | **Complete** |
 | 3 | Claude.ai bridge | Skipped — not required |
-| 4 | Auto-close on merge — `create_pull_request` | **Complete** |
+| 4 | Auto-close on merge — `create_pull_request`, `commit_and_update` | **Complete** |
 | 5 | GitHub Projects v2 (optional) | Planned |
 | 6 | Project site — `okffs.g2mk.dev` | Planned |
 
@@ -103,7 +103,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
    OKFFS_PROMPT_METADATA=true                     # set to false to hide the tip
    OKFFS_BASE_BRANCH=main                         # branch to create issues from; defaults to repo default
    OKFFS_UPDATE_DOCS=false                        # set to true to auto-update project docs on workflow events
-   OKFFS_AUTO_PR=false                            # set to true to auto-create a PR when closing an issue
+   OKFFS_AUTO_PR=false                            # set to true to open a draft PR when a new issue branch is created
    OKFFS_EXCLUDE_DOCS=CLAUDE.md,CONTRIBUTING.md   # comma-separated — valid options: CLAUDE.md, SECURITY.md, CONTRIBUTING.md, CHANGELOG.md
    ```
 
@@ -128,14 +128,15 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
 
 | Tool | Description |
 |------|-------------|
-| `create_issue` | Creates a GitHub issue and a matching branch. Infers labels automatically; merges them with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, and `milestone`. |
+| `create_issue` | Creates a GitHub issue and a matching branch. Infers labels automatically; merges them with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, and `milestone`. If `OKFFS_AUTO_PR=true`, pushes an empty init commit and opens a draft PR for the branch immediately. |
 | `create_issues_from_list` | Creates multiple issues and branches from a task list in one shot. Confirms before acting. Per-task `labels`, `assignees`, and `milestone` supported. |
 | `list_issues` | Lists all open issues with their issue URL and branch URL. |
 | `get_issue` | Fetches full details of an issue — title, body, labels, assignees, branch, and status. |
 | `comment_issue` | Posts a comment to an issue. Useful for logging work done on a branch. |
 | `link_issues` | Links two issues with a relationship — `blocked_by`, `blocking`, or `parent`. Stored in the issue body under a `## Relationships` section. |
-| `close_issue` | Closes a GitHub issue by number. If `OKFFS_AUTO_PR=true`, automatically creates a PR instead of posting a branch comment. |
-| `create_pull_request` | Creates a PR for an issue branch. Generates title and body from the issue, commits, and comments. Always includes `Closes #N`. Posts a summary comment to the issue. |
+| `close_issue` | Closes a GitHub issue by number. Returns a tip to run `/clear` in Claude Code before starting the next issue. |
+| `create_pull_request` | Creates a PR for an issue branch. Generates title and body from the issue, commits, and comments. If `OKFFS_UPDATE_DOCS=true`, commits the updated CHANGELOG onto the branch; pushes the branch before opening the PR. Always includes `Closes #N`. Posts a summary comment to the issue. |
+| `commit_and_update` | Stages all changes, generates a conventional commit message from the diff, commits, pushes to the current branch, and posts a rich progress comment to the linked issue. |
 | `delete_issue` | Closes an issue **and** deletes its matching branch. Destructive — requires `confirmed: true`. |
 | `delete_branch` | Deletes a branch **and** closes its matching issue. Destructive — requires `confirmed: true`. |
 
@@ -146,7 +147,7 @@ Destructive tools (`delete_issue`, `delete_branch`) follow a two-step confirmati
 When `OKFFS_UPDATE_DOCS=true` in your `.env`, okffs will automatically update local project docs when workflow events fire (closing issues, creating PRs, posting comments). Changes are written to local files — committing is your responsibility.
 
 Files updated when relevant:
-- `CHANGELOG.md` — always updated, created if missing. Entries follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. When `OKFFS_AUTO_PR=true`, updated before the PR is created so it's included in the diff.
+- `CHANGELOG.md` — always updated, created if missing. Entries follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. `create_pull_request` updates it before opening the PR and commits it onto the branch so it's included in the diff.
 - `CLAUDE.md` — updated when convention, workflow, tool, config, or architecture keywords are detected.
 - `SECURITY.md` — updated when security, vulnerability, or CVE keywords are detected.
 - `CONTRIBUTING.md` — updated when convention, contributing, or workflow keywords are detected.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
 | `link_issues` | Links two issues with a relationship — `blocked_by`, `blocking`, or `parent`. Stored in the issue body under a `## Relationships` section. |
 | `close_issue` | Closes a GitHub issue by number. Returns a tip to run `/clear` in Claude Code before starting the next issue. |
 | `create_pull_request` | Creates a PR for an issue branch. Generates title and body from the issue, commits, and comments. If `OKFFS_UPDATE_DOCS=true`, commits the updated CHANGELOG onto the branch; pushes the branch before opening the PR. Always includes `Closes #N`. Posts a summary comment to the issue. |
-| `commit_and_update` | Stages all changes, generates a conventional commit message from the diff, commits, pushes to the current branch, and posts a rich progress comment to the linked issue. |
+| `commit_and_update` | Stages all changes, builds a commit message from the provided `hint` (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue. |
 | `delete_issue` | Closes an issue **and** deletes its matching branch. Destructive — requires `confirmed: true`. |
 | `delete_branch` | Deletes a branch **and** closes its matching issue. Destructive — requires `confirmed: true`. |
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "postbuild": "node -e \"const fs=require('fs');const f='dist/index.js';const c=fs.readFileSync(f,'utf8');if(!c.startsWith('#!/usr/bin/env node'))fs.writeFileSync(f,'#!/usr/bin/env node\\n'+c);\" && chmod +x dist/index.js",
     "dev": "node --env-file=.env --import tsx/esm src/index.ts",
     "start": "node --env-file=.env dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okffs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export const config = {
     : [],
   baseBranch: process.env.OKFFS_BASE_BRANCH || null,
   updateDocs: process.env.OKFFS_UPDATE_DOCS === "true",
+  // OKFFS_AUTO_PR=true — creates a draft PR when a new issue branch is created
   autoPR: process.env.OKFFS_AUTO_PR === "true",
   excludeDocs: process.env.OKFFS_EXCLUDE_DOCS
     ? process.env.OKFFS_EXCLUDE_DOCS.split(",").map((s) => s.trim())

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+
+// All git calls pass arguments as an array via execFileSync, so no shell is
+// involved — values like branch names or commit messages (which can originate
+// from issue body text or user input) can never be interpreted as commands.
+
+/** Run a git command with arguments passed as an array. Throws on failure. */
+export function git(args: string[]): void {
+  execFileSync("git", args, { stdio: "ignore" });
+}
+
+/** Run a git command and return its trimmed stdout. Throws on failure. */
+export function gitOutput(args: string[]): string {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+/** Current branch name, or null if it can't be determined. */
+export function currentBranch(): string | null {
+  try {
+    return gitOutput(["rev-parse", "--abbrev-ref", "HEAD"]);
+  } catch {
+    return null;
+  }
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -132,6 +132,18 @@ export async function createPullRequest(
   });
 }
 
+export async function createDraftPullRequest(
+  title: string,
+  body: string,
+  head: string,
+  base: string
+): Promise<{ number: number; html_url: string }> {
+  return request(`/repos/${owner}/${repo}/pulls`, {
+    method: "POST",
+    body: JSON.stringify({ title, head, base, body, draft: true }),
+  });
+}
+
 export function extractBranchFromBody(body: string | null): string | null {
   if (!body) return null;
   const match = body.match(/\*\*Branch:\*\*\s+`([^`]+)`/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,9 @@ import * as commentIssue from "./tools/comment_issue.js";
 import * as createIssuesFromList from "./tools/create_issues_from_list.js";
 import * as linkIssues from "./tools/link_issues.js";
 import * as createPullRequest from "./tools/create_pull_request.js";
+import * as commitAndUpdate from "./tools/commit_and_update.js";
 
-const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, linkIssues, createPullRequest];
+const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, linkIssues, createPullRequest, commitAndUpdate];
 
 const server = new Server(
   { name: "okffs", version: "0.0.1" },

--- a/src/tools/close_issue.ts
+++ b/src/tools/close_issue.ts
@@ -26,7 +26,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     await addIssueComment(input.issue_number, comment);
   }
 
-  if (config.updateDocs) {
+  // In the auto-PR flow, create_pull_request already updates and commits the
+  // CHANGELOG for this issue — skip here to avoid duplicate entries.
+  if (config.updateDocs && !config.autoPR) {
     await updateProjectDocs({
       trigger: "close_issue",
       issueNumber: input.issue_number,

--- a/src/tools/close_issue.ts
+++ b/src/tools/close_issue.ts
@@ -26,21 +26,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     await addIssueComment(input.issue_number, comment);
   }
 
-  if (config.autoPR) {
-    try {
-      const { handler: createPRHandler } = await import("./create_pull_request.js");
-      await createPRHandler({ issue_number: input.issue_number });
-    } catch (err) {
-      console.warn("[okffs] auto PR creation failed:", err);
-      const branchHint = branchName ? ` from branch \`${branchName}\`` : "";
-      await addIssueComment(
-        input.issue_number,
-        `Issue closed. Auto PR creation failed — create the PR manually${branchHint}.`
-      );
-    }
-  }
-
-  if (config.updateDocs && !config.autoPR) {
+  if (config.updateDocs) {
     await updateProjectDocs({
       trigger: "close_issue",
       issueNumber: input.issue_number,
@@ -57,6 +43,6 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   }
 
   return {
-    content: [{ type: "text" as const, text: `Issue #${input.issue_number} closed.` }],
+    content: [{ type: "text" as const, text: `Issue #${input.issue_number} closed.\n\n💡 Tip: run /clear to reset Claude Code context and save tokens before starting the next issue.` }],
   };
 }

--- a/src/tools/commit_and_update.ts
+++ b/src/tools/commit_and_update.ts
@@ -1,0 +1,88 @@
+import { execSync } from "node:child_process";
+import { z } from "zod";
+import { addIssueComment, getIssue, extractBranchFromBody } from "../github.js";
+
+export const name = "commit_and_update";
+export const description =
+  "Stage all changes, generate a conventional commit message from the diff, commit, push to the current branch, and post a rich progress comment to the linked issue.";
+
+export const inputSchema = z.object({
+  issue_number: z.number().int().positive().describe("The issue number this work is against"),
+  hint: z.string().optional().describe("Short description of what was done — used to generate the commit message and issue comment"),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  const issue = await getIssue(input.issue_number);
+  const branchName = extractBranchFromBody(issue.body);
+
+  // Get diff — staged first, fall back to unstaged
+  let diff = "";
+  try {
+    diff = execSync("git diff --staged", { encoding: "utf8" });
+    if (!diff.trim()) {
+      diff = execSync("git diff", { encoding: "utf8" });
+    }
+  } catch {
+    diff = "";
+  }
+
+  // Derive a short conventional commit message from hint + diff file list
+  const changedFiles = (() => {
+    try {
+      return execSync("git diff --name-only HEAD", { encoding: "utf8" })
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  })();
+
+  const hintText = input.hint ?? "";
+  const filesText = changedFiles.length > 0 ? changedFiles.join(", ") : "various files";
+
+  // Build commit message — short conventional format
+  const commitMessage = hintText
+    ? `${hintText.slice(0, 72)}`
+    : `chore: update ${filesText.slice(0, 60)}`;
+
+  // Stage, commit, push
+  let commitHash = "";
+  try {
+    execSync("git add -A", { stdio: "ignore" });
+    execSync(`git commit -m "${commitMessage.replace(/"/g, "'")}"`, { stdio: "ignore" });
+    if (branchName) {
+      execSync(`git push origin ${branchName}`, { stdio: "ignore" });
+    }
+    commitHash = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text" as const, text: `commit_and_update failed: ${msg}` }],
+    };
+  }
+
+  // Post rich comment to issue
+  const timestamp = new Date().toISOString();
+  const filesSection = changedFiles.length > 0
+    ? changedFiles.map((f) => `- \`${f}\``).join("\n")
+    : "- No files detected";
+
+  const comment = [
+    `### 🔧 Commit update`,
+    ``,
+    `**Commit:** \`${commitHash}\``,
+    `**Message:** ${commitMessage}`,
+    `**Time:** ${timestamp}`,
+    ``,
+    `**Files changed:**`,
+    filesSection,
+    hintText ? `\n**Summary:** ${hintText}` : "",
+  ].filter((l) => l !== undefined).join("\n");
+
+  await addIssueComment(input.issue_number, comment);
+
+  return {
+    content: [{ type: "text" as const, text: `Committed \`${commitHash}\` and updated issue #${input.issue_number}.` }],
+  };
+}

--- a/src/tools/commit_and_update.ts
+++ b/src/tools/commit_and_update.ts
@@ -1,65 +1,64 @@
-import { execSync } from "node:child_process";
 import { z } from "zod";
 import { addIssueComment, getIssue, extractBranchFromBody } from "../github.js";
+import { git, gitOutput, currentBranch } from "../git.js";
 
 export const name = "commit_and_update";
 export const description =
-  "Stage all changes, generate a conventional commit message from the diff, commit, push to the current branch, and post a rich progress comment to the linked issue.";
+  "Stage all changes, build a commit message from the provided hint (or the changed file list), commit, push to the issue branch, and post a rich progress comment to the linked issue.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number this work is against"),
-  hint: z.string().optional().describe("Short description of what was done — used to generate the commit message and issue comment"),
+  hint: z.string().optional().describe("Short description of what was done — used to build the commit message and issue comment"),
 });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
   const issue = await getIssue(input.issue_number);
   const branchName = extractBranchFromBody(issue.body);
 
-  // Get diff — staged first, fall back to unstaged
-  let diff = "";
+  // Files changed relative to HEAD — used for the commit message and comment.
+  let changedFiles: string[] = [];
   try {
-    diff = execSync("git diff --staged", { encoding: "utf8" });
-    if (!diff.trim()) {
-      diff = execSync("git diff", { encoding: "utf8" });
-    }
+    changedFiles = gitOutput(["diff", "--name-only", "HEAD"]).split("\n").filter(Boolean);
   } catch {
-    diff = "";
+    changedFiles = [];
   }
-
-  // Derive a short conventional commit message from hint + diff file list
-  const changedFiles = (() => {
-    try {
-      return execSync("git diff --name-only HEAD", { encoding: "utf8" })
-        .trim()
-        .split("\n")
-        .filter(Boolean);
-    } catch {
-      return [];
-    }
-  })();
 
   const hintText = input.hint ?? "";
   const filesText = changedFiles.length > 0 ? changedFiles.join(", ") : "various files";
 
-  // Build commit message — short conventional format
+  // Build the commit message from the hint when provided, else the file list.
   const commitMessage = hintText
-    ? `${hintText.slice(0, 72)}`
+    ? hintText.slice(0, 72)
     : `chore: update ${filesText.slice(0, 60)}`;
 
-  // Stage, commit, push
+  // Stage, commit, and push on the issue branch. Arguments are passed as an
+  // array (no shell), so the hint and branch name can't be interpreted as
+  // shell commands. The caller's original branch is restored afterward.
+  const previousBranch = currentBranch();
   let commitHash = "";
   try {
-    execSync("git add -A", { stdio: "ignore" });
-    execSync(`git commit -m "${commitMessage.replace(/"/g, "'")}"`, { stdio: "ignore" });
-    if (branchName) {
-      execSync(`git push origin ${branchName}`, { stdio: "ignore" });
+    if (branchName && previousBranch !== branchName) {
+      git(["checkout", branchName]);
     }
-    commitHash = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+    git(["add", "-A"]);
+    git(["commit", "-m", commitMessage]);
+    if (branchName) {
+      git(["push", "origin", branchName]);
+    }
+    commitHash = gitOutput(["rev-parse", "--short", "HEAD"]);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {
       content: [{ type: "text" as const, text: `commit_and_update failed: ${msg}` }],
     };
+  } finally {
+    if (branchName && previousBranch && previousBranch !== branchName) {
+      try {
+        git(["checkout", previousBranch]);
+      } catch (err) {
+        console.warn("[okffs] Failed to restore branch:", err instanceof Error ? err.message : err);
+      }
+    }
   }
 
   // Post rich comment to issue

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -1,7 +1,7 @@
-import { execSync } from "node:child_process";
 import { z } from "zod";
 import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, slugify, createDraftPullRequest } from "../github.js";
 import { config } from "../config.js";
+import { git, currentBranch } from "../git.js";
 
 export const name = "create_issue";
 
@@ -33,30 +33,35 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   const updatedBody = `${input.description}\n\n**Branch:** \`${branchName}\``;
   await updateIssueBody(issue.number, updatedBody);
 
-  // Push an empty init commit so the branch diverges from base,
-  // allowing GitHub to accept a draft PR immediately.
-  try {
-    const previousBranch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim();
-    execSync(`git fetch origin`, { stdio: "ignore" });
-    execSync(`git checkout ${branchName}`, { stdio: "ignore" });
-    execSync(`git commit --allow-empty -m "chore: init branch for #${issue.number}"`, { stdio: "ignore" });
-    execSync(`git push origin ${branchName}`, { stdio: "ignore" });
-    if (previousBranch && previousBranch !== branchName) {
-      execSync(`git checkout ${previousBranch}`, { stdio: "ignore" });
-    }
-  } catch (err) {
-    console.warn("[okffs] Failed to push init commit:", err instanceof Error ? err.message : err);
-  }
-
   let draftPRUrl: string | null = null;
   if (config.autoPR) {
+    // Push an empty init commit so the branch diverges from base, allowing
+    // GitHub to accept a draft PR immediately. Only needed for the auto-PR flow.
+    const previousBranch = currentBranch();
     try {
-      const baseBranch = defaultBranch;
+      git(["fetch", "origin"]);
+      git(["checkout", branchName]);
+      git(["commit", "--allow-empty", "-m", `chore: init branch for #${issue.number}`]);
+      git(["push", "origin", branchName]);
+    } catch (err) {
+      console.warn("[okffs] Failed to push init commit:", err instanceof Error ? err.message : err);
+    } finally {
+      // Always restore the caller's original branch, even if a step above failed.
+      if (previousBranch && previousBranch !== branchName) {
+        try {
+          git(["checkout", previousBranch]);
+        } catch (err) {
+          console.warn("[okffs] Failed to restore branch:", err instanceof Error ? err.message : err);
+        }
+      }
+    }
+
+    try {
       const pr = await createDraftPullRequest(
         `WIP: #${issue.number} - ${input.title}`,
         `Closes #${issue.number}`,
         branchName,
-        baseBranch
+        defaultBranch
       );
       draftPRUrl = pr.html_url;
     } catch (err) {

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -1,5 +1,6 @@
+import { execSync } from "node:child_process";
 import { z } from "zod";
-import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, slugify } from "../github.js";
+import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, slugify, createDraftPullRequest } from "../github.js";
 import { config } from "../config.js";
 
 export const name = "create_issue";
@@ -32,10 +33,45 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   const updatedBody = `${input.description}\n\n**Branch:** \`${branchName}\``;
   await updateIssueBody(issue.number, updatedBody);
 
+  // Push an empty init commit so the branch diverges from base,
+  // allowing GitHub to accept a draft PR immediately.
+  try {
+    const previousBranch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim();
+    execSync(`git fetch origin`, { stdio: "ignore" });
+    execSync(`git checkout ${branchName}`, { stdio: "ignore" });
+    execSync(`git commit --allow-empty -m "chore: init branch for #${issue.number}"`, { stdio: "ignore" });
+    execSync(`git push origin ${branchName}`, { stdio: "ignore" });
+    if (previousBranch && previousBranch !== branchName) {
+      execSync(`git checkout ${previousBranch}`, { stdio: "ignore" });
+    }
+  } catch (err) {
+    console.warn("[okffs] Failed to push init commit:", err instanceof Error ? err.message : err);
+  }
+
+  let draftPRUrl: string | null = null;
+  if (config.autoPR) {
+    try {
+      const baseBranch = defaultBranch;
+      const pr = await createDraftPullRequest(
+        `WIP: #${issue.number} - ${input.title}`,
+        `Closes #${issue.number}`,
+        branchName,
+        baseBranch
+      );
+      draftPRUrl = pr.html_url;
+    } catch (err) {
+      console.warn("[okffs] Failed to create draft PR:", err instanceof Error ? err.message : err);
+    }
+  }
+
   const lines = [
     `Issue #${issue.number} created: ${issue.html_url}`,
     `Branch: \`${branchName}\``,
   ];
+
+  if (draftPRUrl) {
+    lines.push(`Draft PR: ${draftPRUrl}`);
+  }
 
   if (resolvedAssignees.length > 0) {
     const source = input.assignees ? "" : " (default)";

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { z } from "zod";
 import {
   getIssue,
@@ -11,6 +10,7 @@ import {
 } from "../github.js";
 import { config } from "../config.js";
 import { updateProjectDocs } from "../docs.js";
+import { git, currentBranch } from "../git.js";
 
 export const name = "create_pull_request";
 
@@ -88,21 +88,41 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const body = bodyParts.join("\n");
 
+  let docsResult: string | null = null;
   if (config.updateDocs) {
-    const docsResult = await updateProjectDocs({
+    docsResult = await updateProjectDocs({
       trigger: "create_pull_request",
       issueNumber: input.issue_number,
       issueTitle: issue.title,
       summary: input.summary ?? cleanedDescription,
       branchName,
     });
+  }
 
-    // If docs were updated, commit the CHANGELOG onto the current (PR) branch so
-    // it's included in the PR diff. A failure here must never block PR creation.
+  // Commit any doc updates and push the branch before opening the PR. Operate on
+  // branchName explicitly so we never commit/push the wrong branch, and restore
+  // the caller's original branch afterward.
+  const previousBranch = currentBranch();
+  try {
+    git(["checkout", branchName]);
+  } catch (err) {
+    console.warn(`[okffs] Failed to checkout branch ${branchName}.`, err instanceof Error ? err.message : err);
+    await addIssueComment(
+      input.issue_number,
+      `PR not created — could not switch to branch \`${branchName}\` locally. Check out the branch, then run \`create_pull_request\` again.`
+    );
+    return {
+      content: [{ type: "text" as const, text: `PR not created — could not switch to branch \`${branchName}\` locally.` }],
+    };
+  }
+
+  try {
+    // If docs were updated, commit the CHANGELOG so it's in the PR diff. A
+    // failure here must never block PR creation.
     if (docsResult) {
       try {
-        execSync("git add CHANGELOG.md", { stdio: "ignore" });
-        execSync(`git commit -m "docs: update CHANGELOG for #${input.issue_number}"`, { stdio: "ignore" });
+        git(["add", "CHANGELOG.md"]);
+        git(["commit", "-m", `docs: update CHANGELOG for #${input.issue_number}`]);
       } catch (err) {
         console.warn(
           `[okffs] Failed to commit CHANGELOG for #${input.issue_number} — continuing without it.`,
@@ -110,24 +130,32 @@ export async function handler(input: z.infer<typeof inputSchema>) {
         );
       }
     }
-  }
 
-  // Push the branch to remote so GitHub sees the commits before PR creation.
-  // If commits exist only locally, the API would report no commits ahead of base.
-  try {
-    execSync(`git push origin ${branchName}`, { stdio: "ignore" });
-  } catch (err) {
-    console.warn(
-      `[okffs] Failed to push branch ${branchName} to remote.`,
-      err instanceof Error ? err.message : err
-    );
-    await addIssueComment(
-      input.issue_number,
-      `PR not created — could not push branch \`${branchName}\` to remote. Please push manually (\`git push origin ${branchName}\`) then run \`create_pull_request\` to continue.`
-    );
-    return {
-      content: [{ type: "text" as const, text: `PR not created — could not push branch \`${branchName}\` to remote. Push manually (\`git push origin ${branchName}\`) then run create_pull_request to continue.` }],
-    };
+    // Push so GitHub sees the commits before PR creation. If commits exist only
+    // locally, the API would report no commits ahead of base.
+    try {
+      git(["push", "origin", branchName]);
+    } catch (err) {
+      console.warn(
+        `[okffs] Failed to push branch ${branchName} to remote.`,
+        err instanceof Error ? err.message : err
+      );
+      await addIssueComment(
+        input.issue_number,
+        `PR not created — could not push branch \`${branchName}\` to remote. Please push manually (\`git push origin ${branchName}\`) then run \`create_pull_request\` to continue.`
+      );
+      return {
+        content: [{ type: "text" as const, text: `PR not created — could not push branch \`${branchName}\` to remote. Push manually (\`git push origin ${branchName}\`) then run create_pull_request to continue.` }],
+      };
+    }
+  } finally {
+    if (previousBranch && previousBranch !== branchName) {
+      try {
+        git(["checkout", previousBranch]);
+      } catch (err) {
+        console.warn(`[okffs] Failed to restore branch ${previousBranch}.`, err instanceof Error ? err.message : err);
+      }
+    }
   }
 
   const pr = await createPullRequest(title, body, branchName, baseBranch);

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { z } from "zod";
 import {
   getIssue,
@@ -88,13 +89,45 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   const body = bodyParts.join("\n");
 
   if (config.updateDocs) {
-    await updateProjectDocs({
+    const docsResult = await updateProjectDocs({
       trigger: "create_pull_request",
       issueNumber: input.issue_number,
       issueTitle: issue.title,
       summary: input.summary ?? cleanedDescription,
       branchName,
     });
+
+    // If docs were updated, commit the CHANGELOG onto the current (PR) branch so
+    // it's included in the PR diff. A failure here must never block PR creation.
+    if (docsResult) {
+      try {
+        execSync("git add CHANGELOG.md", { stdio: "ignore" });
+        execSync(`git commit -m "docs: update CHANGELOG for #${input.issue_number}"`, { stdio: "ignore" });
+      } catch (err) {
+        console.warn(
+          `[okffs] Failed to commit CHANGELOG for #${input.issue_number} — continuing without it.`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+  }
+
+  // Push the branch to remote so GitHub sees the commits before PR creation.
+  // If commits exist only locally, the API would report no commits ahead of base.
+  try {
+    execSync(`git push origin ${branchName}`, { stdio: "ignore" });
+  } catch (err) {
+    console.warn(
+      `[okffs] Failed to push branch ${branchName} to remote.`,
+      err instanceof Error ? err.message : err
+    );
+    await addIssueComment(
+      input.issue_number,
+      `PR not created — could not push branch \`${branchName}\` to remote. Please push manually (\`git push origin ${branchName}\`) then run \`create_pull_request\` to continue.`
+    );
+    return {
+      content: [{ type: "text" as const, text: `PR not created — could not push branch \`${branchName}\` to remote. Push manually (\`git push origin ${branchName}\`) then run create_pull_request to continue.` }],
+    };
   }
 
   const pr = await createPullRequest(title, body, branchName, baseBranch);


### PR DESCRIPTION
Release 0.1.5 — auto-PR flow fixes & enhancements (#38) plus packaging hardening.

## Bug fixes
- `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling.
- `close_issue` returns a `/clear` tip and no longer triggers a PR on close.

## Auto-PR redesign (`OKFFS_AUTO_PR`)
- Draft PR is now opened at branch-creation time by `create_issue` (not on close).
- An empty init commit is pushed first so GitHub accepts the draft PR immediately.

## New tool
- `commit_and_update` — stages, commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.

## Hardening (PR #39 review)
- All git operations go through `src/git.ts` using `execFileSync` with argument arrays — no shell, removing command-injection risk from branch names / commit hints.
- Tools checkout the target branch before committing/pushing and restore the original branch in `finally`.
- Init commit only runs under `OKFFS_AUTO_PR`; `close_issue` skips `updateProjectDocs` in the auto-PR flow to avoid duplicate CHANGELOG entries.

## Packaging
- Added `prepublishOnly` hook so `dist/` is always freshly built before publish.
- Docs (`README.md`, `CLAUDE.md`) updated to match.

## Misc
- Added `.github/instructions/okffs.instructions.md`.
- Version bumped to **0.1.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
