### PR TITLE
Close #41 - feat: add OKFFS_IDENTIFIER env var for project-scoped branch prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ GITHUB_REPO=
 # Branch to create issues from. Defaults to repo default branch if not set.
 OKFFS_BASE_BRANCH=main
 
+# Optional project-scoped prefix inserted into branch names:
+# {issue-number}-{identifier}-{slug} instead of {issue-number}-{slug}
+OKFFS_IDENTIFIER=
+
 # Optional defaults applied to every new issue
 OKFFS_PROMPT_METADATA=true
 OKFFS_DEFAULT_ASSIGNEES=your-github-username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CHANGELOG.md` is now shipped in the npm package.
 
 ### Fixed
+- feat: add OKFFS_IDENTIFIER env var for project-scoped branch prefix ([#41](https://github.com/2b9sa2owa/okffs/issues/41)) — Add optional OKFFS_IDENTIFIER env var that inserts a project-scoped prefix into branch names ({number}-{identifier}-{slug}). Added config flag, a centralized buildBranchName() helper in github.ts, updated create_issue / create_issues_from_list / list_issues to use it, and documented the var in .e...
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@ Guidance for Claude Code when working in this repository.
 42-add-hero-section-to-homepage
 ```
 
+When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-number}-{identifier}-{kebab-title-slug}`.
+
+```
+42-okffs-add-hero-section-to-homepage
+```
+
 ### Pull requests
 
 - Title: `Close #42 - Add hero section to homepage`
@@ -50,8 +56,9 @@ Guidance for Claude Code when working in this repository.
 - `commit_and_update` stages all changes, builds a commit message from the optional `hint` (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.
 - `delete_issue` closes an issue and deletes its branch. Two-step: call once for a warning, re-call with `confirmed: true` to proceed. Posts a comment before acting.
 - `delete_branch` deletes a branch and closes its issue (issue number parsed from branch name prefix). Same two-step confirmation pattern. Posts a comment before acting.
-- Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`, `OKFFS_UPDATE_DOCS`, `OKFFS_AUTO_PR`.
+- Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`, `OKFFS_IDENTIFIER`, `OKFFS_UPDATE_DOCS`, `OKFFS_AUTO_PR`.
 - `OKFFS_BASE_BRANCH` — branch to create new issue branches from. Defaults to the repo's default branch.
+- `OKFFS_IDENTIFIER` — optional project-scoped prefix inserted into branch names: `{issue-number}-{identifier}-{slug}`. Unset by default.
 - `OKFFS_UPDATE_DOCS` — set to `true` to auto-update local project docs (CHANGELOG.md, CLAUDE.md, SECURITY.md, CONTRIBUTING.md) on workflow events. Default `false`. README.md is intentionally excluded.
 - `OKFFS_AUTO_PR` — set to `true` to open a draft PR when a new issue branch is created (via `create_issue`). Default `false`.
 
@@ -102,7 +109,7 @@ Guidance for Claude Code when working in this repository.
 - `.env` holds the GitHub PAT (`GITHUB_TOKEN`) with fine-grained permissions. It is git-ignored — see [.env.example](.env.example).
 - `.env` is loaded automatically at startup via `dotenv` from `process.cwd()`. No `--env-file` flag required in `.mcp.json`.
 - Required: `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`.
-- Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to auto-create PR on issue close), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CLAUDE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`).
+- Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_IDENTIFIER` (optional project-scoped branch prefix: `{number}-{identifier}-{slug}`), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to auto-create PR on issue close), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CLAUDE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`).
 
 ## Local dev vs published package
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
    OKFFS_DEFAULT_LABELS=okffs                     # merged with any inferred labels
    OKFFS_PROMPT_METADATA=true                     # set to false to hide the tip
    OKFFS_BASE_BRANCH=main                         # branch to create issues from; defaults to repo default
+   OKFFS_IDENTIFIER=okffs                         # optional prefix: branches become {number}-{identifier}-{slug}
    OKFFS_UPDATE_DOCS=false                        # set to true to auto-update project docs on workflow events
    OKFFS_AUTO_PR=false                            # set to true to open a draft PR when a new issue branch is created
    OKFFS_EXCLUDE_DOCS=CLAUDE.md,CONTRIBUTING.md   # comma-separated — valid options: CLAUDE.md, SECURITY.md, CONTRIBUTING.md, CHANGELOG.md

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,9 @@ export const config = {
     ? process.env.OKFFS_DEFAULT_LABELS.split(",").map((s) => s.trim())
     : [],
   baseBranch: process.env.OKFFS_BASE_BRANCH || null,
+  // OKFFS_IDENTIFIER — optional project-scoped prefix inserted into branch names:
+  // {issue-number}-{identifier}-{slug} instead of {issue-number}-{slug}
+  identifier: process.env.OKFFS_IDENTIFIER || null,
   updateDocs: process.env.OKFFS_UPDATE_DOCS === "true",
   // OKFFS_AUTO_PR=true — creates a draft PR when a new issue branch is created
   autoPR: process.env.OKFFS_AUTO_PR === "true",

--- a/src/github.ts
+++ b/src/github.ts
@@ -44,6 +44,18 @@ export function slugify(title: string): string {
     .join("-");
 }
 
+/**
+ * Build the branch name for an issue.
+ * Format: {issue-number}-{slug}, or {issue-number}-{identifier}-{slug}
+ * when OKFFS_IDENTIFIER is set.
+ */
+export function buildBranchName(issueNumber: number, title: string): string {
+  const slug = slugify(title);
+  return config.identifier
+    ? `${issueNumber}-${config.identifier}-${slug}`
+    : `${issueNumber}-${slug}`;
+}
+
 export async function createIssue(
   title: string,
   body: string,

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, slugify, createDraftPullRequest } from "../github.js";
+import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, buildBranchName, createDraftPullRequest } from "../github.js";
 import { config } from "../config.js";
 import { git, currentBranch } from "../git.js";
 
@@ -24,7 +24,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const issue = await createIssue(input.title, input.description, resolvedAssignees, resolvedLabels, input.milestone);
 
-  const branchName = `${issue.number}-${slugify(input.title)}`;
+  const branchName = buildBranchName(issue.number, input.title);
 
   const defaultBranch = await getDefaultBranch();
   const ref = await getRef(defaultBranch);

--- a/src/tools/create_issues_from_list.ts
+++ b/src/tools/create_issues_from_list.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, slugify } from "../github.js";
+import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, buildBranchName } from "../github.js";
 import { config } from "../config.js";
 
 export const name = "create_issues_from_list";
@@ -44,7 +44,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     ];
 
     const issue = await createIssue(task.title, task.description, resolvedAssignees, resolvedLabels, task.milestone);
-    const branchName = `${issue.number}-${slugify(task.title)}`;
+    const branchName = buildBranchName(issue.number, task.title);
     await createBranch(branchName, ref.object.sha);
     const updatedBody = `${task.description}\n\n**Branch:** \`${branchName}\``;
     await updateIssueBody(issue.number, updatedBody);

--- a/src/tools/list_issues.ts
+++ b/src/tools/list_issues.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { listIssues, slugify } from "../github.js";
+import { listIssues, buildBranchName } from "../github.js";
 
 const owner = process.env.GITHUB_OWNER;
 const repo = process.env.GITHUB_REPO;
@@ -20,7 +20,7 @@ export async function handler(_input: z.infer<typeof inputSchema>) {
   }
 
   const lines = issues.map((i) => {
-    const branch = `${i.number}-${slugify(i.title)}`;
+    const branch = buildBranchName(i.number, i.title);
     const branchUrl = `https://github.com/${owner}/${repo}/tree/${branch}`;
     return `#${i.number}  ${i.title}\n    issue:  ${i.html_url}\n    branch: ${branchUrl}`;
   });


### PR DESCRIPTION
## Summary
Add optional OKFFS_IDENTIFIER env var that inserts a project-scoped prefix into branch names ({number}-{identifier}-{slug}). Added config flag, a centralized buildBranchName() helper in github.ts, updated create_issue / create_issues_from_list / list_issues to use it, and documented the var in .env.example, README.md, and CLAUDE.md. Builds cleanly.

## Changes
- feat: add OKFFS_IDENTIFIER env var for project-scoped branch prefix

Closes #41