### PR TITLE
Close #42 - feat: add okffs_plan tool — plan and create issues from context in one shot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- New `plan` tool — takes a free-text description plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships), previews the plan, and creates all issues + branches in one shot. Resolves relationships to issue numbers and opens a draft PR per branch when `OKFFS_AUTO_PR=true` ([#42](https://github.com/2b9sa2owa/okffs/issues/42)).
+- `OKFFS_IDENTIFIER` env var — when set, branch names use `{issue-number}-{identifier}-{slug}` instead of `{issue-number}-{slug}` ([#41](https://github.com/2b9sa2owa/okffs/issues/41)).
 
 ## [0.1.5] - 2026-06-26
 ### Added
-- feat: add okffs_plan tool — plan and create issues from context in one shot ([#42](https://github.com/2b9sa2owa/okffs/issues/42)) — Adds a new `plan` tool. It takes a free-text `description` of the work plus the structured issue breakdown Claude generates from it (titles, descriptions, labels, and inter-task relationships referenced by 1-based index), previews the plan, and on `confirmed: true` creates all issues + branches i...
 - New `commit_and_update` tool — stages all changes, builds a commit message from a hint (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.
 - `prepublishOnly` hook so `dist/` is always freshly built before publishing.
 - `.github/instructions/okffs.instructions.md` Copilot instructions file.
@@ -18,7 +20,6 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CHANGELOG.md` is now shipped in the npm package.
 
 ### Fixed
-- feat: add OKFFS_IDENTIFIER env var for project-scoped branch prefix ([#41](https://github.com/2b9sa2owa/okffs/issues/41)) — Add optional OKFFS_IDENTIFIER env var that inserts a project-scoped prefix into branch names ({number}-{identifier}-{slug}). Added config flag, a centralized buildBranchName() helper in github.ts, updated create_issue / create_issues_from_list / list_issues to use it, and documented the var in .e...
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.1.5] - 2026-06-26
 ### Added
+- feat: add okffs_plan tool — plan and create issues from context in one shot ([#42](https://github.com/2b9sa2owa/okffs/issues/42)) — Adds a new `plan` tool. It takes a free-text `description` of the work plus the structured issue breakdown Claude generates from it (titles, descriptions, labels, and inter-task relationships referenced by 1-based index), previews the plan, and on `confirmed: true` creates all issues + branches i...
 - New `commit_and_update` tool — stages all changes, builds a commit message from a hint (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.
 - `prepublishOnly` hook so `dist/` is always freshly built before publishing.
 - `.github/instructions/okffs.instructions.md` Copilot instructions file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,10 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - TypeScript MCP server scaffolded.
 - PAT auth via `.env` (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`).
 - `.env` is loaded automatically via `dotenv` from `process.cwd()` — no `--env-file` flag needed in `.mcp.json`.
-- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `create_pull_request`, `commit_and_update`.
+- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `plan`, `create_pull_request`, `commit_and_update`.
 - `create_issue` auto-creates a branch, embeds the branch name in the issue body, applies default assignees/labels from `.env`, infers labels from title/description and merges with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, `milestone`. If a relationship is mentioned (blocked by, blocking, parent), automatically calls `link_issues` after creation. If `OKFFS_AUTO_PR=true`, pushes an empty init commit to the branch (capturing and restoring the current branch) and opens a draft PR immediately.
 - `create_issues_from_list` accepts a list of tasks and creates all issues + branches in one shot. Two-step confirmation. Per-task `labels`, `assignees`, and `milestone` supported.
+- `plan` takes a free-text `description` plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships referenced by 1-based index) and creates all issues + branches in one shot. Two-step confirmation (preview, then `confirmed: true`). Resolves task-index relationships to real issue numbers and writes them to each issue's `## Relationships` section. If `OKFFS_AUTO_PR=true`, pushes an empty init commit per branch and opens a draft PR for each. Extends the `create_issues_from_list` pattern — Claude is the AI layer that produces the breakdown.
 - `list_issues` returns each issue with its issue URL and inferred branch URL.
 - `get_issue` fetches full issue details — title, body, status, branch, assignees, labels.
 - `comment_issue` posts a comment to an issue. Use after committing to log what was done.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
 |------|-------------|
 | `create_issue` | Creates a GitHub issue and a matching branch. Infers labels automatically; merges them with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, and `milestone`. If `OKFFS_AUTO_PR=true`, pushes an empty init commit and opens a draft PR for the branch immediately. |
 | `create_issues_from_list` | Creates multiple issues and branches from a task list in one shot. Confirms before acting. Per-task `labels`, `assignees`, and `milestone` supported. |
+| `plan` | Takes a free-text description of work plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships) and creates all issues + branches in one shot. Two-step confirmation. Wires up relationships between the new issues; opens a draft PR per branch when `OKFFS_AUTO_PR=true`. |
 | `list_issues` | Lists all open issues with their issue URL and branch URL. |
 | `get_issue` | Fetches full details of an issue — title, body, labels, assignees, branch, and status. |
 | `comment_issue` | Posts a comment to an issue. Useful for logging work done on a branch. |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Once configured, Claude Code will pick up the tools automatically. You can ask C
 - *"Create an issue called 'Fix login button' with description '...'"*
 - *"List all open issues"*
 - *"Create issues from this task list: ..."*
+- *"Plan out the work for adding user authentication and create the issues"*
 - *"Post a comment to issue #12 saying what was done"*
 - *"Mark issue #5 as blocked by issue #3"*
 - *"Done with issue #42, close it and open a PR"*

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -34,6 +34,15 @@ function getChangeType(ctx: DocsContext): string {
   return "Changed";
 }
 
+// Truncate at a word boundary (never mid-word) so summaries don't get cut into
+// a half-word followed by an ellipsis.
+function truncateAtWord(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const slice = text.slice(0, max);
+  const lastSpace = slice.lastIndexOf(" ");
+  return (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).trimEnd() + "…";
+}
+
 function buildChangelogEntry(ctx: DocsContext): string {
   const ref = ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/issues/${ctx.issueNumber}))` : "";
   const title = ctx.issueTitle ?? ctx.trigger;
@@ -42,11 +51,55 @@ function buildChangelogEntry(ctx: DocsContext): string {
     .replace(/\*\*Branch:\*\*\s*`[^`]+`/g, "")
     .replace(/## Relationships[\s\S]*/g, "")
     .replace(/^(Closed:|Fixed:|Added:|Changed:)\s*/i, "")
+    .replace(/\s+/g, " ") // collapse newlines/runs of whitespace into a single line
     .trim();
 
-  const truncated = cleanSummary.length > 300 ? cleanSummary.slice(0, 297) + "..." : cleanSummary;
+  const truncated = truncateAtWord(cleanSummary, 200);
   const summaryPart = truncated && truncated !== title ? ` — ${truncated}` : "";
   return `- ${title}${ref}${summaryPart}`;
+}
+
+// Insert a changelog entry under the ## [Unreleased] section, scoping the search
+// for the type heading (### Added, ### Fixed, …) to that section only. Without
+// scoping, an existing "### Added" under the latest *released* version would
+// match first and the entry would land in the wrong place.
+function insertChangelogEntry(changelog: string, type: string, entry: string): string {
+  const unreleasedMarker = "## [Unreleased]";
+  const typeHeading = `### ${type}`;
+  const markerIdx = changelog.indexOf(unreleasedMarker);
+
+  // No [Unreleased] section yet — add one above the first released version
+  // heading, or at the end of the file if there are none.
+  if (markerIdx === -1) {
+    const block = `${unreleasedMarker}\n${typeHeading}\n${entry}\n\n`;
+    const firstVersionIdx = changelog.search(/\n## \[/);
+    if (firstVersionIdx !== -1) {
+      const at = firstVersionIdx + 1; // preserve the leading newline
+      return changelog.slice(0, at) + block + changelog.slice(at);
+    }
+    return changelog.trimEnd() + "\n\n" + block.trimEnd() + "\n";
+  }
+
+  // Bounds of the [Unreleased] block: from the marker to the next "## " heading.
+  const afterMarker = markerIdx + unreleasedMarker.length;
+  const nextSectionRel = changelog.slice(afterMarker).search(/\n## /);
+  const blockEnd = nextSectionRel === -1 ? changelog.length : afterMarker + nextSectionRel;
+
+  const head = changelog.slice(0, afterMarker);
+  let block = changelog.slice(afterMarker, blockEnd);
+  const tail = changelog.slice(blockEnd);
+
+  const typeIdxInBlock = block.indexOf(typeHeading);
+  if (typeIdxInBlock !== -1) {
+    // Insert right after the existing type heading within the Unreleased block.
+    const insertAt = typeIdxInBlock + typeHeading.length;
+    block = block.slice(0, insertAt) + "\n" + entry + block.slice(insertAt);
+  } else {
+    // Add the type heading and entry at the end of the Unreleased block.
+    block = block.replace(/\s*$/, "") + `\n${typeHeading}\n${entry}\n`;
+  }
+
+  return head + block + tail;
 }
 
 function shouldUpdateSecurity(ctx: DocsContext): boolean {
@@ -92,26 +145,7 @@ function determineUpdates(ctx: DocsContext, base: string): FileUpdate[] {
     const type = getChangeType(ctx);
     const entry = buildChangelogEntry(ctx);
     if (changelog !== null) {
-      const unreleasedMarker = "## [Unreleased]";
-      const typeHeading = `### ${type}`;
-      let newContent: string;
-      if (changelog.includes(unreleasedMarker)) {
-        if (changelog.includes(typeHeading)) {
-          newContent = changelog.replace(typeHeading, typeHeading + "\n" + entry);
-        } else {
-          // Find the end of the [Unreleased] block and append the new type heading there
-          // instead of inserting right after the marker, to avoid gaps between type sections
-          const unreleasedEnd = changelog.indexOf("\n## ", changelog.indexOf(unreleasedMarker) + 1);
-          if (unreleasedEnd !== -1) {
-            newContent = changelog.slice(0, unreleasedEnd) + "\n" + typeHeading + "\n" + entry + changelog.slice(unreleasedEnd);
-          } else {
-            newContent = changelog.trimEnd() + "\n" + typeHeading + "\n" + entry;
-          }
-        }
-      } else {
-        newContent = changelog.trimEnd() + "\n\n" + typeHeading + "\n" + entry;
-      }
-      updates.push({ path: changelogPath, content: newContent, created: false });
+      updates.push({ path: changelogPath, content: insertChangelogEntry(changelog, type, entry), created: false });
     } else {
       updates.push({
         path: changelogPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,12 @@ import * as deleteBranch from "./tools/delete_branch.js";
 import * as getIssue from "./tools/get_issue.js";
 import * as commentIssue from "./tools/comment_issue.js";
 import * as createIssuesFromList from "./tools/create_issues_from_list.js";
+import * as plan from "./tools/plan.js";
 import * as linkIssues from "./tools/link_issues.js";
 import * as createPullRequest from "./tools/create_pull_request.js";
 import * as commitAndUpdate from "./tools/commit_and_update.js";
 
-const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, linkIssues, createPullRequest, commitAndUpdate];
+const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, plan, linkIssues, createPullRequest, commitAndUpdate];
 
 const server = new Server(
   { name: "okffs", version: "0.0.1" },

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -1,0 +1,213 @@
+import { z } from "zod";
+import {
+  createIssue,
+  updateIssueBody,
+  getDefaultBranch,
+  getRef,
+  createBranch,
+  buildBranchName,
+  createDraftPullRequest,
+} from "../github.js";
+import { config } from "../config.js";
+import { git, currentBranch } from "../git.js";
+
+export const name = "plan";
+
+export const description =
+  "Plan a piece of work and create all the resulting GitHub issues (with branches, and draft PRs when OKFFS_AUTO_PR=true) in one shot. Given a free-text description of the work, break it down yourself into a structured list of issues — each with a title, description, inferred labels, and any relationships between them — and pass that breakdown as the tasks array. Infer labels from GitHub's defaults: bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix. Express dependencies via per-task relationships, referencing other tasks by their 1-based position in the list. Two-step confirmation: call once to preview the plan, then re-call with confirmed: true to create everything.";
+
+const relationshipSchema = z.object({
+  type: z
+    .enum(["blocked_by", "blocking", "parent"])
+    .describe(
+      "blocked_by: this task is blocked by the target. blocking: this task is blocking the target. parent: the target is the parent of this task."
+    ),
+  target: z
+    .number()
+    .int()
+    .positive()
+    .describe("1-based index of the related task within this same tasks list"),
+});
+
+const taskSchema = z.object({
+  title: z.string().describe("Issue title"),
+  description: z.string().describe("Issue body / description"),
+  assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
+  labels: z.array(z.string()).optional().describe("Labels to apply to this issue"),
+  milestone: z.number().int().optional().describe("Milestone number to assign"),
+  relationships: z
+    .array(relationshipSchema)
+    .optional()
+    .describe("Relationships to other tasks in this list, referenced by 1-based index"),
+});
+
+export const inputSchema = z.object({
+  description: z
+    .string()
+    .describe("Free-text description of the work to plan and break down into issues"),
+  tasks: z
+    .array(taskSchema)
+    .min(1)
+    .describe("The issue breakdown you generated from the description"),
+  confirmed: z.boolean().optional().describe("Must be true to proceed with creation"),
+});
+
+const RELATIONSHIP_LABELS: Record<string, string> = {
+  blocked_by: "Blocked by",
+  blocking: "Blocking",
+  parent: "Parent:",
+};
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  if (!input.confirmed) {
+    const preview = input.tasks
+      .map((t, i) => {
+        const labels = t.labels?.length ? ` [${t.labels.join(", ")}]` : "";
+        const rels =
+          t.relationships?.length
+            ? "\n" +
+              t.relationships
+                .map((r) => `     ↳ ${RELATIONSHIP_LABELS[r.type]} task ${r.target}`)
+                .join("\n")
+            : "";
+        return `${i + 1}. ${t.title}${labels}${rels}`;
+      })
+      .join("\n");
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text:
+            `Plan for: ${input.description}\n\n` +
+            `About to create ${input.tasks.length} issue(s):\n\n${preview}\n\n` +
+            `Re-call plan with confirmed: true to create them.`,
+        },
+      ],
+    };
+  }
+
+  const defaultBranch = await getDefaultBranch();
+  const ref = await getRef(defaultBranch);
+
+  // First pass: create every issue and its branch so we have real issue numbers
+  // before wiring up relationships (which reference tasks by list index).
+  const created: Array<{
+    number: number;
+    html_url: string;
+    branchName: string;
+    body: string;
+    relationships: z.infer<typeof relationshipSchema>[];
+  }> = [];
+
+  for (const task of input.tasks) {
+    const resolvedAssignees = task.assignees ?? config.defaultAssignees;
+    const resolvedLabels = [...new Set([...(task.labels ?? []), ...config.defaultLabels])];
+
+    const issue = await createIssue(
+      task.title,
+      task.description,
+      resolvedAssignees,
+      resolvedLabels,
+      task.milestone
+    );
+    const branchName = buildBranchName(issue.number, task.title);
+    await createBranch(branchName, ref.object.sha);
+
+    const body = `${task.description}\n\n**Branch:** \`${branchName}\``;
+    await updateIssueBody(issue.number, body);
+
+    created.push({
+      number: issue.number,
+      html_url: issue.html_url,
+      branchName,
+      body,
+      relationships: task.relationships ?? [],
+    });
+  }
+
+  // Second pass: resolve relationship targets (1-based task indices) to issue
+  // numbers and append a Relationships section to the relevant issue bodies.
+  for (let i = 0; i < created.length; i++) {
+    const entry = created[i];
+    const lines = entry.relationships
+      .filter((r) => r.target >= 1 && r.target <= created.length && r.target !== i + 1)
+      .map((r) => `- ${RELATIONSHIP_LABELS[r.type]} #${created[r.target - 1].number}`);
+
+    if (lines.length === 0) continue;
+
+    const newBody = `${entry.body}\n\n## Relationships\n${lines.join("\n")}`;
+    await updateIssueBody(entry.number, newBody);
+  }
+
+  // Optionally open a draft PR per branch. Mirrors create_issue: push an empty
+  // init commit so the branch diverges from base, then open the draft PR.
+  const draftPRs: Record<number, string> = {};
+  if (config.autoPR) {
+    const previousBranch = currentBranch();
+    try {
+      git(["fetch", "origin"]);
+      for (const entry of created) {
+        try {
+          git(["checkout", entry.branchName]);
+          git(["commit", "--allow-empty", "-m", `chore: init branch for #${entry.number}`]);
+          git(["push", "origin", entry.branchName]);
+        } catch (err) {
+          console.warn(
+            `[okffs] Failed to push init commit for #${entry.number}:`,
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
+    } finally {
+      if (previousBranch && !created.some((e) => e.branchName === previousBranch)) {
+        try {
+          git(["checkout", previousBranch]);
+        } catch (err) {
+          console.warn(
+            "[okffs] Failed to restore branch:",
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
+    }
+
+    for (const entry of created) {
+      try {
+        const pr = await createDraftPullRequest(
+          `WIP: #${entry.number} - ${input.tasks[created.indexOf(entry)].title}`,
+          `Closes #${entry.number}`,
+          entry.branchName,
+          defaultBranch
+        );
+        draftPRs[entry.number] = pr.html_url;
+      } catch (err) {
+        console.warn(
+          `[okffs] Failed to create draft PR for #${entry.number}:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+  }
+
+  const results = created.map((entry) => {
+    const lines = [
+      `#${entry.number} — ${input.tasks[created.indexOf(entry)].title}`,
+      `  Branch: \`${entry.branchName}\``,
+      `  ${entry.html_url}`,
+    ];
+    if (draftPRs[entry.number]) {
+      lines.push(`  Draft PR: ${draftPRs[entry.number]}`);
+    }
+    return lines.join("\n");
+  });
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Created ${results.length} issue(s) from the plan:\n\n${results.join("\n\n")}`,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
Adds a new `plan` tool. It takes a free-text `description` of the work plus the structured issue breakdown Claude generates from it (titles, descriptions, labels, and inter-task relationships referenced by 1-based index), previews the plan, and on `confirmed: true` creates all issues + branches in one shot. Inter-task relationships are resolved to real issue numbers and written to each issue's `## Relationships` section. When `OKFFS_AUTO_PR=true`, an empty init commit is pushed per branch and a draft PR opened for each. Two-step confirmation mirrors `create_issues_from_list`. Registered in the tool index; README and CLAUDE.md updated. Branch rebased on develop; builds cleanly.

## Changes
- feat: add plan tool — break down work and create issues in one shot

Closes #42