### PR TITLE
Close #47 - restrict OKFFS_UPDATE_DOCS changelog triggers to create_pull_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `plan` tool — takes a free-text description plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships), previews the plan, and creates all issues + branches in one shot. Resolves relationships to issue numbers and opens a draft PR per branch when `OKFFS_AUTO_PR=true` ([#42](https://github.com/2b9sa2owa/okffs/issues/42)).
 - `OKFFS_IDENTIFIER` env var — when set, branch names use `{issue-number}-{identifier}-{slug}` instead of `{issue-number}-{slug}` ([#41](https://github.com/2b9sa2owa/okffs/issues/41)).
 
+### Changed
+- `OKFFS_UPDATE_DOCS` auto-changelog now fires only on `create_pull_request`. `comment_issue` and `close_issue` no longer trigger doc updates, making `create_pull_request` the single source of changelog entries and eliminating noisy/duplicate entries ([#47](https://github.com/2b9sa2owa/okffs/issues/47)).
+
 ## [0.1.5] - 2026-06-26
 ### Added
 - New `commit_and_update` tool — stages all changes, builds a commit message from a hint (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`, `OKFFS_IDENTIFIER`, `OKFFS_UPDATE_DOCS`, `OKFFS_AUTO_PR`.
 - `OKFFS_BASE_BRANCH` — branch to create new issue branches from. Defaults to the repo's default branch.
 - `OKFFS_IDENTIFIER` — optional project-scoped prefix inserted into branch names: `{issue-number}-{identifier}-{slug}`. Unset by default.
-- `OKFFS_UPDATE_DOCS` — set to `true` to auto-update local project docs (CHANGELOG.md, CLAUDE.md, SECURITY.md, CONTRIBUTING.md) on workflow events. Default `false`. README.md is intentionally excluded.
+- `OKFFS_UPDATE_DOCS` — set to `true` to auto-update local project docs (CHANGELOG.md, CLAUDE.md, SECURITY.md, CONTRIBUTING.md) when a pull request is created (`create_pull_request`). Default `false`. README.md is intentionally excluded. `comment_issue` and `close_issue` do not trigger doc updates — `create_pull_request` is the single source of auto-changelog entries (avoids duplicate/noisy entries).
 - `OKFFS_AUTO_PR` — set to `true` to open a draft PR when a new issue branch is created (via `create_issue`). Default `false`.
 
 ### Phase 2 — Bulk creation ✓ Complete

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ Destructive tools (`delete_issue`, `delete_branch`) follow a two-step confirmati
 
 ## Automatic doc updates
 
-When `OKFFS_UPDATE_DOCS=true` in your `.env`, okffs will automatically update local project docs when workflow events fire (closing issues, creating PRs, posting comments). Changes are written to local files — committing is your responsibility.
+When `OKFFS_UPDATE_DOCS=true` in your `.env`, okffs automatically updates local project docs when a pull request is created (`create_pull_request`). Changes are written to local files — committing is your responsibility. Commenting on or closing an issue does **not** trigger doc updates, to keep the CHANGELOG free of noise and duplicate entries.
 
 Files updated when relevant:
-- `CHANGELOG.md` — always updated, created if missing. Entries follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. `create_pull_request` updates it before opening the PR and commits it onto the branch so it's included in the diff.
+- `CHANGELOG.md` — always updated, created if missing. Entries follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format, added under `## [Unreleased]`. `create_pull_request` updates it before opening the PR and commits it onto the branch so it's included in the diff. This is the single source of auto-changelog entries.
 - `CLAUDE.md` — updated when convention, workflow, tool, config, or architecture keywords are detected.
 - `SECURITY.md` — updated when security, vulnerability, or CVE keywords are detected.
 - `CONTRIBUTING.md` — updated when convention, contributing, or workflow keywords are detected.

--- a/src/tools/close_issue.ts
+++ b/src/tools/close_issue.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { closeIssue, getIssue, addIssueComment, extractBranchFromBody, owner, repo } from "../github.js";
 import { config } from "../config.js";
-import { updateProjectDocs } from "../docs.js";
 
 export const name = "close_issue";
 
@@ -26,23 +25,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     await addIssueComment(input.issue_number, comment);
   }
 
-  // In the auto-PR flow, create_pull_request already updates and commits the
-  // CHANGELOG for this issue — skip here to avoid duplicate entries.
-  if (config.updateDocs && !config.autoPR) {
-    await updateProjectDocs({
-      trigger: "close_issue",
-      issueNumber: input.issue_number,
-      issueTitle: issue.title,
-      summary: issue.body
-        ? issue.body
-            .replace(/\*\*Branch:\*\*\s*`[^`]+`/g, "")
-            .replace(/## Relationships[\s\S]*/g, "")
-            .trim()
-            .slice(0, 200)
-        : issue.title,
-      branchName: branchName ?? undefined,
-    });
-  }
+  // Closing no longer triggers a CHANGELOG update. create_pull_request is the
+  // single source of auto-changelog entries — firing here too produced
+  // duplicates (the PR already logged the change).
 
   return {
     content: [{ type: "text" as const, text: `Issue #${input.issue_number} closed.\n\n💡 Tip: run /clear to reset Claude Code context and save tokens before starting the next issue.` }],

--- a/src/tools/comment_issue.ts
+++ b/src/tools/comment_issue.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
-import { addIssueComment, getIssue, owner, repo } from "../github.js";
-import { config } from "../config.js";
-import { updateProjectDocs } from "../docs.js";
+import { addIssueComment, owner, repo } from "../github.js";
 
 export const name = "comment_issue";
 
@@ -14,17 +12,10 @@ export const inputSchema = z.object({
 });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
+  // Note: commenting intentionally does not trigger CHANGELOG updates — it is
+  // too frequent to be a meaningful changelog event. create_pull_request is the
+  // single source of auto-changelog entries.
   await addIssueComment(input.issue_number, input.comment);
-
-  if (config.updateDocs) {
-    const issue = await getIssue(input.issue_number);
-    await updateProjectDocs({
-      trigger: "comment_issue",
-      issueNumber: input.issue_number,
-      issueTitle: issue.title,
-      summary: input.comment.slice(0, 300),
-    });
-  }
 
   return {
     content: [


### PR DESCRIPTION
Closes #47

Makes `create_pull_request` the single source of auto-changelog entries.

- `comment_issue` — removed the `updateProjectDocs` trigger entirely (too frequent to be a meaningful changelog event).
- `close_issue` — removed its `updateProjectDocs` trigger (`create_pull_request` already logs the change; firing here duplicated it). The previous `!config.autoPR` guard only covered the AUTO_PR=true case; an AUTO_PR=false + `create_pull_request` + `close_issue` path still duplicated.
- Docs — README "Automatic doc updates" and CLAUDE.md updated to describe the single-trigger model.
- CHANGELOG — `[Unreleased]` entry added manually (this branch was opened as an AUTO_PR draft, so `create_pull_request` couldn't run — see #49).

Build passes (`tsc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)