### PR TITLE
Close #49 - bug: OKFFS_AUTO_PR=true leaves CHANGELOG with no auto-update trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - `OKFFS_UPDATE_DOCS` auto-changelog now fires only on `create_pull_request`. `comment_issue` and `close_issue` no longer trigger doc updates, making `create_pull_request` the single source of changelog entries and eliminating noisy/duplicate entries ([#47](https://github.com/2b9sa2owa/okffs/issues/47)).
+### Fixed
+- bug: OKFFS_AUTO_PR=true leaves CHANGELOG with no auto-update trigger ([#49](https://github.com/2b9sa2owa/okffs/issues/49)) — create_pull_request now reuses an existing open PR for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true): it updates the title/body and marks the draft ready for review…
 
 ## [0.1.5] - 2026-06-26
 ### Added

--- a/src/github.ts
+++ b/src/github.ts
@@ -34,6 +34,28 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+async function graphqlRequest<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const res = await fetch(`${BASE}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub GraphQL error ${res.status}: ${body}`);
+  }
+
+  const json = (await res.json()) as { data?: T; errors?: unknown };
+  if (json.errors) {
+    throw new Error(`GitHub GraphQL error: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data as T;
+}
+
 export function slugify(title: string): string {
   return title
     .toLowerCase()
@@ -200,6 +222,36 @@ export async function createPullRequest(
     method: "POST",
     body: JSON.stringify({ title, head, base, body }),
   });
+}
+
+// Find the open PR (if any) whose head is the given branch. Used to reuse a
+// draft PR created up front by create_issue under OKFFS_AUTO_PR=true.
+export async function getOpenPullRequestForBranch(
+  branch: string
+): Promise<{ number: number; html_url: string; node_id: string; draft: boolean } | null> {
+  const prs = await request<Array<{ number: number; html_url: string; node_id: string; draft: boolean }>>(
+    `/repos/${owner}/${repo}/pulls?head=${owner}:${branch}&state=open&per_page=1`
+  );
+  return prs.length > 0 ? prs[0] : null;
+}
+
+export async function updatePullRequest(
+  prNumber: number,
+  fields: { title?: string; body?: string }
+): Promise<void> {
+  await request(`/repos/${owner}/${repo}/pulls/${prNumber}`, {
+    method: "PATCH",
+    body: JSON.stringify(fields),
+  });
+}
+
+// Mark a draft PR ready for review. The REST update endpoint cannot change the
+// draft flag, so this uses the GraphQL markPullRequestReadyForReview mutation.
+export async function markPullRequestReady(nodeId: string): Promise<void> {
+  await graphqlRequest(
+    `mutation($id: ID!) { markPullRequestReadyForReview(input: { pullRequestId: $id }) { pullRequest { id } } }`,
+    { id: nodeId }
+  );
 }
 
 export async function createDraftPullRequest(

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -6,6 +6,9 @@ import {
   getBranchCommits,
   getIssueComments,
   createPullRequest,
+  getOpenPullRequestForBranch,
+  updatePullRequest,
+  markPullRequestReady,
   addIssueComment,
 } from "../github.js";
 import { config } from "../config.js";
@@ -15,7 +18,7 @@ import { git, currentBranch } from "../git.js";
 export const name = "create_pull_request";
 
 export const description =
-  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, updates CHANGELOG before creating the PR. Posts a summary comment to the issue.";
+  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, updates CHANGELOG before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. Posts a summary comment to the issue.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to create a PR for"),
@@ -158,16 +161,40 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     }
   }
 
-  const pr = await createPullRequest(title, body, branchName, baseBranch);
+  // Under OKFFS_AUTO_PR=true a draft PR already exists for this branch (opened by
+  // create_issue), so creating one would fail. Detect and finalize it instead:
+  // update title/body and mark it ready for review. Otherwise create a new PR.
+  const existing = await getOpenPullRequestForBranch(branchName);
+  let pr: { number: number; html_url: string };
+  let action: string;
+
+  if (existing) {
+    await updatePullRequest(existing.number, { title, body });
+    if (existing.draft) {
+      try {
+        await markPullRequestReady(existing.node_id);
+      } catch (err) {
+        console.warn(
+          `[okffs] Failed to mark PR #${existing.number} ready for review — leaving it as a draft.`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+    pr = { number: existing.number, html_url: existing.html_url };
+    action = existing.draft ? "finalized (marked ready)" : "updated";
+  } else {
+    pr = await createPullRequest(title, body, branchName, baseBranch);
+    action = "created";
+  }
 
   const comment = [
-    `PR opened: ${pr.html_url}`,
+    `PR ${action}: ${pr.html_url}`,
     ``,
     body,
   ].join("\n");
   await addIssueComment(input.issue_number, comment);
 
   return {
-    content: [{ type: "text" as const, text: `PR #${pr.number} created: ${pr.html_url}` }],
+    content: [{ type: "text" as const, text: `PR #${pr.number} ${action}: ${pr.html_url}` }],
   };
 }


### PR DESCRIPTION
## Summary
create_pull_request now reuses an existing open PR for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true): it updates the title/body and marks the draft ready for review instead of erroring, so the CHANGELOG is written in the AUTO_PR flow too. Adds getOpenPullRequestForBranch, updatePullRequest, and markPullRequestReady (GraphQL) to github.ts.

## Changes
- chore: init branch for #49
- fix: reuse existing draft PR in create_pull_request (AUTO_PR flow)

Closes #49