### PR TITLE
Close #51 - fix: docs reference main for auto-close but workflow merges to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - `OKFFS_UPDATE_DOCS` auto-changelog now fires only on `create_pull_request`. `comment_issue` and `close_issue` no longer trigger doc updates, making `create_pull_request` the single source of changelog entries and eliminating noisy/duplicate entries ([#47](https://github.com/2b9sa2owa/okffs/issues/47)).
 ### Fixed
+- fix: docs reference main for auto-close but workflow merges to develop ([#51](https://github.com/2b9sa2owa/okffs/issues/51)) — Corrects the auto-close documentation and adds a runtime guard. GitHub's `Closes #N` only auto-closes an issue when the PR merges into the repository's default branch; with…
 - bug: OKFFS_AUTO_PR=true leaves CHANGELOG with no auto-update trigger ([#49](https://github.com/2b9sa2owa/okffs/issues/49)) — create_pull_request now reuses an existing open PR for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true): it updates the title/body and marks the draft ready for review…
 
 ## [0.1.5] - 2026-06-26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 ### Pull requests
 
 - Title: `Close #42 - Add hero section to homepage`
-- Body **always** includes `Closes #42` — this triggers GitHub's native auto-close when the PR merges to `main`.
+- Body **always** includes `Closes #42` — this triggers GitHub's native auto-close **only when the PR merges into the repository's default branch** (usually `main`). If `OKFFS_BASE_BRANCH` points at a non-default branch (e.g. `develop`), GitHub will **not** auto-close the issue on merge — close it manually with `close_issue`. `create_pull_request` warns when the PR targets a non-default base.
 
 ## Build phases
 
@@ -83,7 +83,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - Before creating the PR, the branch is pushed to remote (`git push origin <branch>`). If the push fails, a comment is posted to the issue and the PR is not created.
 - `OKFFS_AUTO_PR` no longer triggers a PR on close — the draft PR is opened at branch-creation time by `create_issue`. To accept the draft PR immediately, `create_issue` first pushes an empty init commit so the branch diverges from base.
 - `commit_and_update` tool — stages all changes, generates a conventional commit message, commits, pushes to the current branch, and posts a rich progress comment to the linked issue.
-- GitHub natively closes the issue on merge via `Closes #N` — no webhook infrastructure needed.
+- GitHub natively closes the issue on merge via `Closes #N` — no webhook infrastructure needed. Note: this only fires when merging into the repo's default branch. With a `develop`-based workflow (`OKFFS_BASE_BRANCH=develop`), merge to `develop` does not auto-close; use `close_issue`.
 - Edge case: if the branch has no commits ahead of the base branch, a friendly comment is posted instead of erroring.
 
 ### Phase 5 — GitHub Projects v2 (optional, later)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ README.md is intentionally excluded from auto-updates — maintain it manually.
 **Pull requests:**
 
 - Title: `Close #42 - Add hero section to homepage`
-- Body always includes `Closes #42` so GitHub auto-closes the issue when the PR merges to `main`.
+- Body always includes `Closes #42` so GitHub auto-closes the issue when the PR merges into the repository's **default branch** (usually `main`). If you set `OKFFS_BASE_BRANCH` to a non-default branch (e.g. `develop`), GitHub will not auto-close on merge — close the issue manually with `close_issue`. `create_pull_request` flags this when the PR targets a non-default base.
 
 **Operating principles:**
 

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -196,26 +196,27 @@ function determineUpdates(ctx: DocsContext, base: string): FileUpdate[] {
   return updates;
 }
 
-export async function updateProjectDocs(ctx: DocsContext): Promise<string | null> {
+// Returns the paths of the files that were actually written, so callers can
+// stage exactly those (rather than assuming only CHANGELOG.md changed).
+export async function updateProjectDocs(ctx: DocsContext): Promise<string[]> {
   try {
     const base = process.cwd();
     const updates = determineUpdates(ctx, base);
-    if (updates.length === 0) return null;
+    if (updates.length === 0) return [];
 
-    const results: string[] = [];
+    const written: string[] = [];
     for (const u of updates) {
       try {
         fs.writeFileSync(u.path, u.content, "utf8");
-        const name = path.basename(u.path);
-        results.push(u.created ? `created ${name}` : `updated ${name}`);
+        written.push(u.path);
       } catch (err) {
         console.warn(`[okffs] docs: failed to write ${u.path}:`, err);
       }
     }
 
-    return results.length > 0 ? results.join(", ") : null;
+    return written;
   } catch (err) {
     console.warn("[okffs] docs: unexpected error:", err);
-    return null;
+    return [];
   }
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -104,6 +104,13 @@ export async function getDefaultBranch(): Promise<string> {
   return data.default_branch;
 }
 
+// The repository's actual default branch, ignoring OKFFS_BASE_BRANCH. GitHub's
+// `Closes #N` only auto-closes the issue when a PR merges into this branch.
+export async function getRepoDefaultBranch(): Promise<string> {
+  const data = await request<{ default_branch: string }>(`/repos/${owner}/${repo}`);
+  return data.default_branch;
+}
+
 export async function getRef(ref: string): Promise<{ object: { sha: string } }> {
   return request(`/repos/${owner}/${repo}/git/ref/heads/${ref}`);
 }

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -106,9 +106,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const body = bodyParts.join("\n");
 
-  let docsResult: string | null = null;
+  let updatedDocs: string[] = [];
   if (config.updateDocs) {
-    docsResult = await updateProjectDocs({
+    updatedDocs = await updateProjectDocs({
       trigger: "create_pull_request",
       issueNumber: input.issue_number,
       issueTitle: issue.title,
@@ -135,15 +135,17 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   }
 
   try {
-    // If docs were updated, commit the CHANGELOG so it's in the PR diff. A
-    // failure here must never block PR creation.
-    if (docsResult) {
+    // If docs were updated, commit all of them so they're in the PR diff —
+    // not just CHANGELOG.md (updateProjectDocs may also touch CLAUDE.md,
+    // CONTRIBUTING.md, SECURITY.md). A failure here must never block PR creation.
+    if (updatedDocs.length > 0) {
       try {
-        git(["add", "CHANGELOG.md"]);
-        git(["commit", "-m", `docs: update CHANGELOG for #${input.issue_number}`]);
+        const names = updatedDocs.map((p) => p.split(/[\\/]/).pop()).join(", ");
+        git(["add", ...updatedDocs]);
+        git(["commit", "-m", `docs: update ${names} for #${input.issue_number}`]);
       } catch (err) {
         console.warn(
-          `[okffs] Failed to commit CHANGELOG for #${input.issue_number} — continuing without it.`,
+          `[okffs] Failed to commit doc updates for #${input.issue_number} — continuing without them.`,
           err instanceof Error ? err.message : err
         );
       }

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -9,6 +9,7 @@ import {
   getOpenPullRequestForBranch,
   updatePullRequest,
   markPullRequestReady,
+  getRepoDefaultBranch,
   addIssueComment,
 } from "../github.js";
 import { config } from "../config.js";
@@ -40,6 +41,20 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   }
 
   const baseBranch = await getDefaultBranch();
+
+  // `Closes #N` only auto-closes the issue when the PR merges into the repo's
+  // default branch. If OKFFS_BASE_BRANCH targets a non-default branch (e.g.
+  // develop), warn that the issue must be closed manually after merge.
+  let autoCloseNote = "";
+  if (config.baseBranch) {
+    const repoDefault = await getRepoDefaultBranch();
+    if (baseBranch !== repoDefault) {
+      autoCloseNote =
+        `\n\n⚠️ This PR targets \`${baseBranch}\`, not the default branch \`${repoDefault}\` — ` +
+        `merging will **not** auto-close #${input.issue_number}. Close it manually with \`close_issue\` after merge.`;
+    }
+  }
+
   const commits = await getBranchCommits(branchName, baseBranch);
   const comments = await getIssueComments(input.issue_number);
 
@@ -191,10 +206,10 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     `PR ${action}: ${pr.html_url}`,
     ``,
     body,
-  ].join("\n");
+  ].join("\n") + autoCloseNote;
   await addIssueComment(input.issue_number, comment);
 
   return {
-    content: [{ type: "text" as const, text: `PR #${pr.number} ${action}: ${pr.html_url}` }],
+    content: [{ type: "text" as const, text: `PR #${pr.number} ${action}: ${pr.html_url}${autoCloseNote}` }],
   };
 }


### PR DESCRIPTION
## Summary
Corrects the auto-close documentation and adds a runtime guard. GitHub's `Closes #N` only auto-closes an issue when the PR merges into the repository's default branch; with `OKFFS_BASE_BRANCH=develop` it never fired. CLAUDE.md and README now state this clearly and note that a develop-based workflow requires manual `close_issue`. `create_pull_request` now warns — in both the issue comment and its output — when the PR base is not the repo's default branch. Added `getRepoDefaultBranch()` (the true default, ignoring OKFFS_BASE_BRANCH) to github.ts.

## Changes
- chore: init branch for #51
- fix: clarify auto-close docs and warn on non-default PR base

Closes #51