### PR TITLE
fix: address PR #53 Copilot review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,20 @@ All notable changes to this project will be documented in this file.
 See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## [0.1.6] - 2026-06-27
 ### Added
+- `plan` tool — takes a free-text description plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships), previews the plan, and creates all issues + branches (and draft PRs when `OKFFS_AUTO_PR=true`) in one shot. Resolves relationships to issue numbers and writes them to each issue's `## Relationships` section ([#42](https://github.com/2b9sa2owa/okffs/issues/42)).
 - Redesigned `list_issues` — each open issue now shows its branch + URL, any linked open/draft PR (matched by head branch), and its relationships (parent, children, blocked-by, blocking) as a tree ([#43](https://github.com/2b9sa2owa/okffs/issues/43)).
-- New `plan` tool — takes a free-text description plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships), previews the plan, and creates all issues + branches in one shot. Resolves relationships to issue numbers and opens a draft PR per branch when `OKFFS_AUTO_PR=true` ([#42](https://github.com/2b9sa2owa/okffs/issues/42)).
 - `OKFFS_IDENTIFIER` env var — when set, branch names use `{issue-number}-{identifier}-{slug}` instead of `{issue-number}-{slug}` ([#41](https://github.com/2b9sa2owa/okffs/issues/41)).
 
 ### Changed
-- `OKFFS_UPDATE_DOCS` auto-changelog now fires only on `create_pull_request`. `comment_issue` and `close_issue` no longer trigger doc updates, making `create_pull_request` the single source of changelog entries and eliminating noisy/duplicate entries ([#47](https://github.com/2b9sa2owa/okffs/issues/47)).
+- `OKFFS_UPDATE_DOCS` auto-changelog now fires only on `create_pull_request`; `comment_issue` and `close_issue` no longer trigger doc updates, making `create_pull_request` the single source of changelog entries and eliminating noisy/duplicate entries ([#47](https://github.com/2b9sa2owa/okffs/issues/47)).
+- `create_pull_request` now commits all updated docs (CLAUDE.md, CONTRIBUTING.md, SECURITY.md), not just CHANGELOG.md.
+
 ### Fixed
-- fix: docs reference main for auto-close but workflow merges to develop ([#51](https://github.com/2b9sa2owa/okffs/issues/51)) — Corrects the auto-close documentation and adds a runtime guard. GitHub's `Closes #N` only auto-closes an issue when the PR merges into the repository's default branch; with…
-- bug: OKFFS_AUTO_PR=true leaves CHANGELOG with no auto-update trigger ([#49](https://github.com/2b9sa2owa/okffs/issues/49)) — create_pull_request now reuses an existing open PR for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true): it updates the title/body and marks the draft ready for review…
+- `OKFFS_AUTO_PR=true` left the CHANGELOG with no auto-update trigger. `create_pull_request` now reuses an existing open PR for the branch (e.g. a draft opened by `create_issue`), updating it and marking it ready for review instead of erroring ([#49](https://github.com/2b9sa2owa/okffs/issues/49)).
+- Docs incorrectly claimed `Closes #N` auto-closes on merge to `main`; it only fires when merging into the repo's default branch. Corrected the docs and added a warning in `create_pull_request` when the PR base isn't the default branch ([#51](https://github.com/2b9sa2owa/okffs/issues/51)).
 
 ## [0.1.5] - 2026-06-26
 ### Added
@@ -30,5 +34,6 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/2b9sa2owa/okffs/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/2b9sa2owa/okffs/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/2b9sa2owa/okffs/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/2b9sa2owa/okffs/compare/v0.1.4...v0.1.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "okffs",
-  "version": "0.1.0",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "okffs",
-      "version": "0.1.0",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okffs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -196,8 +196,10 @@ function determineUpdates(ctx: DocsContext, base: string): FileUpdate[] {
   return updates;
 }
 
-// Returns the paths of the files that were actually written, so callers can
-// stage exactly those (rather than assuming only CHANGELOG.md changed).
+// Returns the repo-relative paths of the files that were actually written, so
+// callers can stage exactly those (rather than assuming only CHANGELOG.md
+// changed). Paths are relative to base (process.cwd()) so they pass cleanly to
+// `git add`, which runs from the same working directory.
 export async function updateProjectDocs(ctx: DocsContext): Promise<string[]> {
   try {
     const base = process.cwd();
@@ -208,7 +210,7 @@ export async function updateProjectDocs(ctx: DocsContext): Promise<string[]> {
     for (const u of updates) {
       try {
         fs.writeFileSync(u.path, u.content, "utf8");
-        written.push(u.path);
+        written.push(path.relative(base, u.path));
       } catch (err) {
         console.warn(`[okffs] docs: failed to write ${u.path}:`, err);
       }

--- a/src/github.ts
+++ b/src/github.ts
@@ -69,12 +69,14 @@ export function slugify(title: string): string {
 /**
  * Build the branch name for an issue.
  * Format: {issue-number}-{slug}, or {issue-number}-{identifier}-{slug}
- * when OKFFS_IDENTIFIER is set.
+ * when OKFFS_IDENTIFIER is set. The identifier is slugified too, so spaces or
+ * other characters invalid in a git ref can't break branch creation.
  */
 export function buildBranchName(issueNumber: number, title: string): string {
   const slug = slugify(title);
-  return config.identifier
-    ? `${issueNumber}-${config.identifier}-${slug}`
+  const identifier = config.identifier ? slugify(config.identifier) : "";
+  return identifier
+    ? `${issueNumber}-${identifier}-${slug}`
     : `${issueNumber}-${slug}`;
 }
 

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -19,7 +19,7 @@ import { git, currentBranch } from "../git.js";
 export const name = "create_pull_request";
 
 export const description =
-  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, updates CHANGELOG before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. Posts a summary comment to the issue.";
+  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, updates the project docs (CHANGELOG.md, and when relevant CLAUDE.md, CONTRIBUTING.md, SECURITY.md) and commits them onto the branch before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. Posts a summary comment to the issue.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to create a PR for"),


### PR DESCRIPTION
Addresses the three Copilot review comments on #53.

- **docs.ts** — `updateProjectDocs` now returns repo-relative paths instead of absolute ones, so they pass cleanly to `git add` in `create_pull_request` (absolute paths could be rejected as outside the repo).
- **github.ts** — `buildBranchName` now slugifies `OKFFS_IDENTIFIER`, so an identifier containing spaces or other characters invalid in a git ref can't break branch creation (e.g. `My Proj!` → `my-proj`).
- **create_pull_request.ts** — tool description updated to reflect that all updated docs (CHANGELOG.md, CLAUDE.md, CONTRIBUTING.md, SECURITY.md) are committed, not just CHANGELOG.

Targets `develop` so it flows into the develop→main release PR #53. Build passes; both behavioral fixes verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)