### PR TITLE
Close #56 - feat: reduce auth/setup friction for end users (tiered, low-complexity first)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,12 @@
 # GitHub Configuration
+#
+# Token: set GITHUB_TOKEN, or leave it blank to fall back to the GitHub CLI
+# (`gh auth login`). Create a token in one click:
+#   https://github.com/settings/tokens/new?scopes=repo&description=okffs
 GITHUB_TOKEN=
+#
+# Repository: optional — auto-detected from the `origin` git remote of the
+# directory okffs runs in. Set these only to override the detected values.
 GITHUB_OWNER=
 GITHUB_REPO=
 

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
 # GitHub Configuration
 #
 # Token: set GITHUB_TOKEN, or leave it blank to fall back to the GitHub CLI
-# (`gh auth login`). Create a token in one click:
-#   https://github.com/settings/tokens/new?scopes=repo&description=okffs
+# (`gh auth login`). Two ways to create a token:
+#   - Fine-grained PAT (recommended, least privilege): Issues, Contents,
+#     Pull requests (read/write), Metadata (read), Administration (read/write)
+#     https://github.com/settings/personal-access-tokens/new
+#   - Classic PAT (quickest, but broad `repo` scope across all your repos):
+#     https://github.com/settings/tokens/new?scopes=repo&description=okffs
 GITHUB_TOKEN=
 #
 # Repository: optional — auto-detected from the `origin` git remote of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- feat: reduce auth/setup friction for end users (tiered, low-complexity first) ([#56](https://github.com/2b9sa2owa/okffs/issues/56)) — Implements Tier 1 + Tier 2 of the auth/setup friction reduction. Token now resolves from GITHUB_TOKEN or falls back to the GitHub CLI (`gh auth token`); owner/repo resolve from…
 
 ## [0.1.6] - 2026-06-27
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,4 +134,4 @@ uvx --from "semble[mcp]" semble search "your query" .
 ```
 
 ## Recent Changes
-- 2026-06-28 ([#56](https://github.com/2b9sa2owa/okffs/issues/56)): Implements Tier 1 + Tier 2 of the auth/setup friction reduction. Token now resolves from GITHUB_TOKEN or falls back to the GitHub CLI (`gh auth token`); owner/repo resolve from GITHUB_OWNER/GITHUB_REP
+- 2026-06-28 ([#56](https://github.com/2b9sa2owa/okffs/issues/56)): Reduced auth/setup friction — token resolves from `GITHUB_TOKEN` or falls back to `gh auth token`; owner/repo auto-detect from the `origin` git remote when env vars are unset.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,9 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 
 - `.env` holds the GitHub PAT (`GITHUB_TOKEN`) with fine-grained permissions. It is git-ignored — see [.env.example](.env.example).
 - `.env` is loaded automatically at startup via `dotenv` from `process.cwd()`. No `--env-file` flag required in `.mcp.json`.
-- Required: `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`.
+- Auth resolution: `GITHUB_TOKEN` if set, otherwise falls back to the GitHub CLI (`gh auth token`). If neither is available, startup fails with a message linking to the one-click PAT page.
+- Repo resolution: `GITHUB_OWNER`/`GITHUB_REPO` if set, otherwise auto-detected by parsing the `origin` git remote of `process.cwd()`. So with `gh` signed in and okffs run inside the target repo, no `.env` is required.
+- Resolution lives in `src/github.ts` (`resolveToken`, `resolveOwnerRepo`); `owner`/`repo` are exported from there and reused (e.g. `docs.ts`) so detected values flow everywhere.
 - Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_IDENTIFIER` (optional project-scoped branch prefix: `{number}-{identifier}-{slug}`), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to auto-create PR on issue close), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CLAUDE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`).
 
 ## Local dev vs published package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,3 +132,6 @@ To search manually:
 ```bash
 uvx --from "semble[mcp]" semble search "your query" .
 ```
+
+## Recent Changes
+- 2026-06-28 ([#56](https://github.com/2b9sa2owa/okffs/issues/56)): Implements Tier 1 + Tier 2 of the auth/setup friction reduction. Token now resolves from GITHUB_TOKEN or falls back to the GitHub CLI (`gh auth token`); owner/repo resolve from GITHUB_OWNER/GITHUB_REP

--- a/README.md
+++ b/README.md
@@ -38,10 +38,23 @@ Add okffs to any project by creating a `.mcp.json` in the project root:
 }
 ```
 
-Create a `.env` file in the same directory with your GitHub credentials:
+### Authentication & repository
+
+okffs needs a GitHub token and a target repository. It resolves both with sensible fallbacks, so most users need little or no config:
+
+**Token** (in order of preference):
+1. `GITHUB_TOKEN` in a `.env` file. Create a token with one click: [github.com/settings/tokens/new?scopes=repo&description=okffs](https://github.com/settings/tokens/new?scopes=repo&description=okffs).
+2. If `GITHUB_TOKEN` is unset, okffs falls back to the **GitHub CLI** — if you've run `gh auth login`, it just works with no token setup.
+
+**Repository** (in order of preference):
+1. `GITHUB_OWNER` / `GITHUB_REPO` in `.env`.
+2. If unset, okffs **auto-detects** them from the `origin` git remote of the directory it runs in.
+
+So the minimal setup is often just the `.mcp.json` above — if you're signed in with `gh` and run okffs inside the repo you want to manage, no `.env` is needed at all. To configure explicitly, create a `.env` in the same directory:
 
 ```env
 GITHUB_TOKEN=ghp_your_personal_access_token_here
+# Optional — auto-detected from the git `origin` remote when omitted:
 GITHUB_OWNER=your-github-username
 GITHUB_REPO=your-repo-name
 ```
@@ -88,12 +101,12 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
    cp .env.example .env
    ```
 
-   Required vars:
+   Auth & repo (all optional if you use the `gh` CLI and run inside the target repo — see [Authentication & repository](#authentication--repository)):
 
    ```env
-   GITHUB_TOKEN=ghp_your_personal_access_token_here
-   GITHUB_OWNER=your-github-username
-   GITHUB_REPO=your-repo-name
+   GITHUB_TOKEN=ghp_your_personal_access_token_here   # or sign in with `gh auth login`
+   GITHUB_OWNER=your-github-username                  # auto-detected from git origin if omitted
+   GITHUB_REPO=your-repo-name                         # auto-detected from git origin if omitted
    ```
 
 3. Optionally set defaults applied to every new issue:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Add okffs to any project by creating a `.mcp.json` in the project root:
 okffs needs a GitHub token and a target repository. It resolves both with sensible fallbacks, so most users need little or no config:
 
 **Token** (in order of preference):
-1. `GITHUB_TOKEN` in a `.env` file. Create a token with one click: [github.com/settings/tokens/new?scopes=repo&description=okffs](https://github.com/settings/tokens/new?scopes=repo&description=okffs).
+1. `GITHUB_TOKEN` in a `.env` file. Two ways to create one:
+   - **Fine-grained PAT (recommended, least privilege)** — [create one here](https://github.com/settings/personal-access-tokens/new) with **Issues**, **Contents**, **Pull requests** (read/write), **Metadata** (read), and **Administration** (read/write) on the target repo. See [Prerequisites](#prerequisites).
+   - **Classic PAT (quickest)** — one-click pre-scoped link: [github.com/settings/tokens/new?scopes=repo&description=okffs](https://github.com/settings/tokens/new?scopes=repo&description=okffs). Note this grants the **broad `repo` scope** across all your repos; prefer the fine-grained option above if you want to limit access.
 2. If `GITHUB_TOKEN` is unset, okffs falls back to the **GitHub CLI** — if you've run `gh auth login`, it just works with no token setup.
 
 **Repository** (in order of preference):

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { config } from "./config.js";
+import { owner, repo } from "./github.js";
 
 // Scoped to: CLAUDE.md, CHANGELOG.md, SECURITY.md, CONTRIBUTING.md
 // CHANGELOG.md is created if missing. Others are only updated if they exist.
@@ -44,7 +45,7 @@ function truncateAtWord(text: string, max: number): string {
 }
 
 function buildChangelogEntry(ctx: DocsContext): string {
-  const ref = ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/issues/${ctx.issueNumber}))` : "";
+  const ref = ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${owner}/${repo}/issues/${ctx.issueNumber}))` : "";
   const title = ctx.issueTitle ?? ctx.trigger;
 
   const cleanSummary = ctx.summary
@@ -160,7 +161,7 @@ function determineUpdates(ctx: DocsContext, base: string): FileUpdate[] {
     const claudePath = path.join(base, "CLAUDE.md");
     const claude = readFile(claudePath);
     if (claude !== null) {
-      const line = `\n- ${isoDate()}${ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}/issues/${ctx.issueNumber}))` : ""}: ${ctx.summary.slice(0, 200)}`;
+      const line = `\n- ${isoDate()}${ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${owner}/${repo}/issues/${ctx.issueNumber}))` : ""}: ${ctx.summary.slice(0, 200)}`;
       updates.push({
         path: claudePath,
         content: appendToSection(claude, "## Recent Changes", line),

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -161,7 +161,7 @@ function determineUpdates(ctx: DocsContext, base: string): FileUpdate[] {
     const claudePath = path.join(base, "CLAUDE.md");
     const claude = readFile(claudePath);
     if (claude !== null) {
-      const line = `\n- ${isoDate()}${ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${owner}/${repo}/issues/${ctx.issueNumber}))` : ""}: ${ctx.summary.slice(0, 200)}`;
+      const line = `\n- ${isoDate()}${ctx.issueNumber ? ` ([#${ctx.issueNumber}](https://github.com/${owner}/${repo}/issues/${ctx.issueNumber}))` : ""}: ${truncateAtWord(ctx.summary.replace(/\s+/g, " ").trim(), 200)}`;
       updates.push({
         path: claudePath,
         content: appendToSection(claude, "## Recent Changes", line),

--- a/src/github.ts
+++ b/src/github.ts
@@ -58,7 +58,9 @@ export const repo = resolved.repo;
 
 if (!token) {
   throw new Error(
-    `No GitHub token found. Set GITHUB_TOKEN in .env (create one at ${PAT_LINK}), or sign in with the GitHub CLI (\`gh auth login\`).`
+    `No GitHub token found. Set GITHUB_TOKEN in .env — a fine-grained PAT (least privilege; ` +
+      `Issues/Contents/Pull requests read-write, Metadata read, Administration read-write) or, for a quick start, ` +
+      `a classic broad repo-scope token: ${PAT_LINK} — or sign in with the GitHub CLI (\`gh auth login\`).`
   );
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,13 +1,71 @@
+import { execFileSync } from "node:child_process";
 import { config } from "./config.js";
 
 const BASE = "https://api.github.com";
 
-const token = process.env.GITHUB_TOKEN;
-export const owner = process.env.GITHUB_OWNER;
-export const repo = process.env.GITHUB_REPO;
+const PAT_LINK =
+  "https://github.com/settings/tokens/new?scopes=repo&description=okffs";
 
-if (!token || !owner || !repo) {
-  throw new Error("GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO must be set");
+/** Run a command and return trimmed stdout, or null on any failure. */
+function tryExec(cmd: string, args: string[]): string | null {
+  try {
+    const out = execFileSync(cmd, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a GitHub token. Prefers GITHUB_TOKEN, then falls back to the GitHub
+ * CLI (`gh auth token`) so users already signed in with `gh` need no setup.
+ */
+function resolveToken(): string | null {
+  return process.env.GITHUB_TOKEN || tryExec("gh", ["auth", "token"]);
+}
+
+/** Parse owner/repo from a GitHub remote URL (https or ssh form). */
+function parseOwnerRepo(remoteUrl: string): { owner: string; repo: string } | null {
+  const m = remoteUrl.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+  return m ? { owner: m[1], repo: m[2] } : null;
+}
+
+/**
+ * Resolve owner/repo. Prefers explicit env vars, then auto-detects from the
+ * `origin` git remote of the current working directory.
+ */
+function resolveOwnerRepo(): { owner?: string; repo?: string } {
+  let owner = process.env.GITHUB_OWNER;
+  let repo = process.env.GITHUB_REPO;
+  if (!owner || !repo) {
+    const remote = tryExec("git", ["remote", "get-url", "origin"]);
+    const parsed = remote ? parseOwnerRepo(remote) : null;
+    if (parsed) {
+      owner = owner || parsed.owner;
+      repo = repo || parsed.repo;
+    }
+  }
+  return { owner, repo };
+}
+
+const token = resolveToken();
+const resolved = resolveOwnerRepo();
+export const owner = resolved.owner;
+export const repo = resolved.repo;
+
+if (!token) {
+  throw new Error(
+    `No GitHub token found. Set GITHUB_TOKEN in .env (create one at ${PAT_LINK}), or sign in with the GitHub CLI (\`gh auth login\`).`
+  );
+}
+
+if (!owner || !repo) {
+  throw new Error(
+    "Could not determine the GitHub repository. Run okffs from inside a git repo with a GitHub `origin` remote, or set GITHUB_OWNER and GITHUB_REPO in .env."
+  );
 }
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {


### PR DESCRIPTION
## Summary
Implements Tier 1 + Tier 2 of the auth/setup friction reduction. Token now resolves from GITHUB_TOKEN or falls back to the GitHub CLI (`gh auth token`); owner/repo resolve from GITHUB_OWNER/GITHUB_REPO or are auto-detected from the `origin` git remote. Startup errors are actionable (missing token links to the one-click PAT page; undetectable repo explains the fix). Resolution is centralized in github.ts and reused by docs.ts. Documented the new setup flow in README (new "Authentication & repository" section), .env.example, and CLAUDE.md. Tier 3 (OAuth device flow) intentionally deferred.

## Changes
- chore: init branch for #56
- feat: auto-detect repo and fall back to gh auth (reduce setup friction)

Closes #56