### PR TITLE
Close #58 - feat: PR review-response workflow (tools + MCP prompt) for handling PR comments out of the box

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,5 +32,9 @@ OKFFS_UPDATE_DOCS=false
 # Set to true to automatically create a PR when closing an issue
 OKFFS_AUTO_PR=false
 
+# Set to true to let okffs auto-resolve PR review threads after they're
+# addressed. Default false: threads are left open for you to read and resolve.
+OKFFS_RESOLVE_THREADS=false
+
 # Comma-separated filenames to exclude from doc updates e.g. CLAUDE.md,SECURITY.md
 OKFFS_EXCLUDE_DOCS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-### Changed
-- feat: PR review-response workflow (tools + MCP prompt) for handling PR comments out of the box ([#58](https://github.com/2b9sa2owa/okffs/issues/58)) — Adds an out-of-the-box PR review-response workflow. New tools: list_pr_review_comments (fetch inline threads + review summaries via GraphQL, with comment ids, file/line, author, body, resolved state,…
-- feat: reduce auth/setup friction for end users (tiered, low-complexity first) ([#56](https://github.com/2b9sa2owa/okffs/issues/56)) — Implements Tier 1 + Tier 2 of the auth/setup friction reduction. Token now resolves from GITHUB_TOKEN or falls back to the GitHub CLI (`gh auth token`); owner/repo resolve from…
+### Added
+- PR review-response workflow: new `list_pr_review_comments`, `reply_to_review_comment`, and `resolve_review_thread` tools, plus an `address_pr_review` MCP prompt (slash command) that reads a PR's review comments, fixes them, replies per thread, and posts a summary. Thread resolution is gated by the new `OKFFS_RESOLVE_THREADS` env var (default off) ([#58](https://github.com/2b9sa2owa/okffs/issues/58)).
+- Reduced auth/setup friction: token resolves from `GITHUB_TOKEN` or falls back to `gh auth token`, and owner/repo auto-detect from the `origin` git remote when env vars are unset ([#56](https://github.com/2b9sa2owa/okffs/issues/56)).
 
 ## [0.1.6] - 2026-06-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
+- feat: PR review-response workflow (tools + MCP prompt) for handling PR comments out of the box ([#58](https://github.com/2b9sa2owa/okffs/issues/58)) — Adds an out-of-the-box PR review-response workflow. New tools: list_pr_review_comments (fetch inline threads + review summaries via GraphQL, with comment ids, file/line, author, body, resolved state,…
 - feat: reduce auth/setup friction for end users (tiered, low-complexity first) ([#56](https://github.com/2b9sa2owa/okffs/issues/56)) — Implements Tier 1 + Tier 2 of the auth/setup friction reduction. Token now resolves from GITHUB_TOKEN or falls back to the GitHub CLI (`gh auth token`); owner/repo resolve from…
 
 ## [0.1.6] - 2026-06-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,8 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - TypeScript MCP server scaffolded.
 - PAT auth via `.env` (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`).
 - `.env` is loaded automatically via `dotenv` from `process.cwd()` — no `--env-file` flag needed in `.mcp.json`.
-- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `plan`, `create_pull_request`, `commit_and_update`.
+- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `plan`, `create_pull_request`, `commit_and_update`, `list_pr_review_comments`, `reply_to_review_comment`, `resolve_review_thread`.
+- Prompts (MCP `prompts` capability, surfaced as slash commands): `address_pr_review` — read a PR's review comments, fix the valid ones, reply per thread, post a summary, and optionally resolve threads.
 - `create_issue` auto-creates a branch, embeds the branch name in the issue body, applies default assignees/labels from `.env`, infers labels from title/description and merges with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, `milestone`. If a relationship is mentioned (blocked by, blocking, parent), automatically calls `link_issues` after creation. If `OKFFS_AUTO_PR=true`, pushes an empty init commit to the branch (capturing and restoring the current branch) and opens a draft PR immediately.
 - `create_issues_from_list` accepts a list of tasks and creates all issues + branches in one shot. Two-step confirmation. Per-task `labels`, `assignees`, and `milestone` supported.
 - `plan` takes a free-text `description` plus the issue breakdown Claude generates from it (titles, descriptions, labels, inter-task relationships referenced by 1-based index) and creates all issues + branches in one shot. Two-step confirmation (preview, then `confirmed: true`). Resolves task-index relationships to real issue numbers and writes them to each issue's `## Relationships` section. If `OKFFS_AUTO_PR=true`, pushes an empty init commit per branch and opens a draft PR for each. Extends the `create_issues_from_list` pattern — Claude is the AI layer that produces the breakdown.
@@ -55,6 +56,10 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - `link_issues` links two issues with a relationship — `blocked_by`, `blocking`, or `parent`. Stored in the issue body under a `## Relationships` section.
 - `close_issue` closes the issue and returns a tip suggesting the user runs `/clear` in Claude Code to reset context before the next issue. (Under `OKFFS_AUTO_PR=true` the draft PR already exists from `create_issue`, so no PR is created here.)
 - `commit_and_update` stages all changes, builds a commit message from the optional `hint` (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue.
+- `list_pr_review_comments` fetches a PR's review feedback via GraphQL — inline threads (comment ids, file/line, author, body, resolved state, thread ids) and review summaries. The agent reads these, fixes, then replies/resolves.
+- `reply_to_review_comment` replies to an inline review comment thread by id (REST `in_reply_to`).
+- `resolve_review_thread` resolves a review thread (GraphQL). Gated by `OKFFS_RESOLVE_THREADS`: declines unless that env var is `true`, leaving threads for the user to resolve manually.
+- `address_pr_review` (MCP prompt / slash command) orchestrates the loop: `list_pr_review_comments` → triage + fix → `commit_and_update` → `reply_to_review_comment` per thread → `comment_issue` summary → `resolve_review_thread` (respects `OKFFS_RESOLVE_THREADS`). The host LLM provides triage/fixes; okffs provides the plumbing.
 - `delete_issue` closes an issue and deletes its branch. Two-step: call once for a warning, re-call with `confirmed: true` to proceed. Posts a comment before acting.
 - `delete_branch` deletes a branch and closes its issue (issue number parsed from branch name prefix). Same two-step confirmation pattern. Posts a comment before acting.
 - Optional `.env` defaults: `OKFFS_DEFAULT_ASSIGNEES`, `OKFFS_DEFAULT_LABELS`, `OKFFS_PROMPT_METADATA`, `OKFFS_BASE_BRANCH`, `OKFFS_IDENTIFIER`, `OKFFS_UPDATE_DOCS`, `OKFFS_AUTO_PR`.
@@ -62,6 +67,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - `OKFFS_IDENTIFIER` — optional project-scoped prefix inserted into branch names: `{issue-number}-{identifier}-{slug}`. Unset by default.
 - `OKFFS_UPDATE_DOCS` — set to `true` to auto-update local project docs (CHANGELOG.md, CLAUDE.md, SECURITY.md, CONTRIBUTING.md) when a pull request is created (`create_pull_request`). Default `false`. README.md is intentionally excluded. `comment_issue` and `close_issue` do not trigger doc updates — `create_pull_request` is the single source of auto-changelog entries (avoids duplicate/noisy entries).
 - `OKFFS_AUTO_PR` — set to `true` to open a draft PR when a new issue branch is created (via `create_issue`). Default `false`.
+- `OKFFS_RESOLVE_THREADS` — set to `true` to let okffs auto-resolve PR review threads after they're addressed (via `resolve_review_thread`). Default `false` — threads are left open for the user to resolve.
 
 ### Phase 2 — Bulk creation ✓ Complete
 
@@ -112,7 +118,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - Auth resolution: `GITHUB_TOKEN` if set, otherwise falls back to the GitHub CLI (`gh auth token`). If neither is available, startup fails with a message linking to the one-click PAT page.
 - Repo resolution: `GITHUB_OWNER`/`GITHUB_REPO` if set, otherwise auto-detected by parsing the `origin` git remote of `process.cwd()`. So with `gh` signed in and okffs run inside the target repo, no `.env` is required.
 - Resolution lives in `src/github.ts` (`resolveToken`, `resolveOwnerRepo`); `owner`/`repo` are exported from there and reused (e.g. `docs.ts`) so detected values flow everywhere.
-- Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_IDENTIFIER` (optional project-scoped branch prefix: `{number}-{identifier}-{slug}`), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to auto-create PR on issue close), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CLAUDE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`).
+- Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_IDENTIFIER` (optional project-scoped branch prefix: `{number}-{identifier}-{slug}`), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to auto-create PR on issue close), `OKFFS_RESOLVE_THREADS` (set to `true` to auto-resolve PR review threads after addressing; default leaves them for the user), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CLAUDE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CHANGELOG.md`).
 
 ## Local dev vs published package
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,5 +140,5 @@ uvx --from "semble[mcp]" semble search "your query" .
 ```
 
 ## Recent Changes
-- 2026-06-28 ([#58](https://github.com/2b9sa2owa/okffs/issues/58)): Adds an out-of-the-box PR review-response workflow. New tools: list_pr_review_comments (fetch inline threads + review summaries via GraphQL, with comment ids, file/line, author, body, resolved state, 
+- 2026-06-28 ([#58](https://github.com/2b9sa2owa/okffs/issues/58)): Added an out-of-the-box PR review-response workflow — `list_pr_review_comments`, `reply_to_review_comment`, and `resolve_review_thread` tools plus an `address_pr_review` MCP prompt, gated by `OKFFS_RESOLVE_THREADS`.
 - 2026-06-28 ([#56](https://github.com/2b9sa2owa/okffs/issues/56)): Reduced auth/setup friction — token resolves from `GITHUB_TOKEN` or falls back to `gh auth token`; owner/repo auto-detect from the `origin` git remote when env vars are unset.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,4 +140,5 @@ uvx --from "semble[mcp]" semble search "your query" .
 ```
 
 ## Recent Changes
+- 2026-06-28 ([#58](https://github.com/2b9sa2owa/okffs/issues/58)): Adds an out-of-the-box PR review-response workflow. New tools: list_pr_review_comments (fetch inline threads + review summaries via GraphQL, with comment ids, file/line, author, body, resolved state, 
 - 2026-06-28 ([#56](https://github.com/2b9sa2owa/okffs/issues/56)): Reduced auth/setup friction — token resolves from `GITHUB_TOKEN` or falls back to `gh auth token`; owner/repo auto-detect from the `origin` git remote when env vars are unset.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,3 +74,6 @@ Use conventional commits:
 ## Publishing
 
 Maintainer only. Bump `package.json` version, merge to `main`, tag with `vX.Y.Z` — GitHub Actions handles the npm publish automatically.
+
+## Changelog
+- 2026-06-28: Adds an out-of-the-box PR review-response workflow. New tools: list_pr_review_comments (fetch inline threads + review summaries via GraphQL, with comment ids, file/line, author, body, resolved state, and thread ids), reply_to_review_comment (reply to a thread by id), and resolve_review_thread (resolve via GraphQL, gated by the new OKFFS_RESOLVE_THREADS env var — declines unless enabled so threads are left for the user by default). Adds an MCP prompt address_pr_review (surfaced as a slash command) that orchestrates read → triage/fix → commit_and_update → reply per thread → comment_issue summary → optional resolve, and wires up the MCP prompts capability in index.ts. Top-level PR summary comments reuse comment_issue (PRs are issues). Documented in README (tools table + new "Responding to PR reviews" section), .env.example, and CLAUDE.md. Verified live against PR #57 (threads, ids, replies parsed correctly), the resolve guard, and the prompt builder.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
    OKFFS_IDENTIFIER=okffs                         # optional prefix: branches become {number}-{identifier}-{slug}
    OKFFS_UPDATE_DOCS=false                        # set to true to auto-update project docs on workflow events
    OKFFS_AUTO_PR=false                            # set to true to open a draft PR when a new issue branch is created
+   OKFFS_RESOLVE_THREADS=false                    # set to true to let okffs auto-resolve PR review threads after they're addressed
    OKFFS_EXCLUDE_DOCS=CLAUDE.md,CONTRIBUTING.md   # comma-separated — valid options: CLAUDE.md, SECURITY.md, CONTRIBUTING.md, CHANGELOG.md
    ```
 
@@ -155,10 +156,26 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
 | `close_issue` | Closes a GitHub issue by number. Returns a tip to run `/clear` in Claude Code before starting the next issue. |
 | `create_pull_request` | Creates a PR for an issue branch. Generates title and body from the issue, commits, and comments. If `OKFFS_UPDATE_DOCS=true`, commits the updated CHANGELOG onto the branch; pushes the branch before opening the PR. Always includes `Closes #N`. Posts a summary comment to the issue. |
 | `commit_and_update` | Stages all changes, builds a commit message from the provided `hint` (or the changed file list), commits, pushes to the issue branch, and posts a rich progress comment to the linked issue. |
+| `list_pr_review_comments` | Fetches a PR's review feedback: inline comment threads (with comment ids, file/line, author, body, resolved state) and review summaries. |
+| `reply_to_review_comment` | Replies to an inline PR review comment thread by id. |
+| `resolve_review_thread` | Marks a PR review thread resolved. Gated by `OKFFS_RESOLVE_THREADS` — declines unless that's enabled, leaving threads for you to resolve. |
 | `delete_issue` | Closes an issue **and** deletes its matching branch. Destructive — requires `confirmed: true`. |
 | `delete_branch` | Deletes a branch **and** closes its matching issue. Destructive — requires `confirmed: true`. |
 
 Destructive tools (`delete_issue`, `delete_branch`) follow a two-step confirmation pattern: call once to see a warning, then re-call with `confirmed: true` to proceed. A comment is posted to the issue before any action is taken.
+
+## Responding to PR reviews
+
+okffs ships a workflow for handling pull request review feedback out of the box. Just ask Claude in natural language, e.g.:
+
+- *"Address the review comments on PR #42"*
+- *"Can you fix any of the commented issues on the PR?"*
+
+Claude reads the review threads (`list_pr_review_comments`), fixes the valid ones, commits and pushes (`commit_and_update`), replies to each thread (`reply_to_review_comment`), and posts an overall summary (`comment_issue`). Claude provides the judgment and code fixes; okffs provides the GitHub plumbing.
+
+There's also a ready-made prompt exposed as a slash command — **`/okffs:address_pr_review`** (takes a PR number) — that runs the same loop.
+
+Review threads are only auto-resolved when `OKFFS_RESOLVE_THREADS=true`; by default they're left open for you to read and resolve yourself.
 
 ## Automatic doc updates
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,9 @@ export const config = {
   updateDocs: process.env.OKFFS_UPDATE_DOCS === "true",
   // OKFFS_AUTO_PR=true — creates a draft PR when a new issue branch is created
   autoPR: process.env.OKFFS_AUTO_PR === "true",
+  // OKFFS_RESOLVE_THREADS=true — auto-resolve PR review threads after they are
+  // addressed. Default false: threads are left open for the user to resolve.
+  resolveThreads: process.env.OKFFS_RESOLVE_THREADS === "true",
   excludeDocs: process.env.OKFFS_EXCLUDE_DOCS
     ? process.env.OKFFS_EXCLUDE_DOCS.split(",").map((s) => s.trim())
     : [],

--- a/src/github.ts
+++ b/src/github.ts
@@ -340,3 +340,109 @@ export function extractBranchFromBody(body: string | null): string | null {
   const match = body.match(/\*\*Branch:\*\*\s+`([^`]+)`/);
   return match ? match[1] : null;
 }
+
+// ── PR review feedback ──────────────────────────────────────────────────────
+
+export interface ReviewComment {
+  id: number; // REST databaseId — used as in_reply_to when replying
+  path: string | null;
+  line: number | null;
+  author: string;
+  body: string;
+}
+
+export interface ReviewThread {
+  id: string; // GraphQL node id — used to resolve the thread
+  isResolved: boolean;
+  comments: ReviewComment[];
+}
+
+export interface ReviewSummary {
+  author: string;
+  state: string;
+  body: string;
+}
+
+export interface PullRequestReview {
+  threads: ReviewThread[];
+  reviews: ReviewSummary[];
+}
+
+// Fetch inline review threads (with resolved state + thread ids) and overall
+// review summaries for a PR. Uses GraphQL so we get thread ids and resolved
+// state, which the REST comments endpoint does not expose.
+export async function getPullRequestReview(prNumber: number): Promise<PullRequestReview> {
+  const data = await graphqlRequest<{
+    repository: {
+      pullRequest: {
+        reviewThreads: {
+          nodes: Array<{
+            id: string;
+            isResolved: boolean;
+            comments: {
+              nodes: Array<{
+                databaseId: number;
+                path: string | null;
+                line: number | null;
+                originalLine: number | null;
+                body: string;
+                author: { login: string } | null;
+              }>;
+            };
+          }>;
+        };
+        reviews: {
+          nodes: Array<{ state: string; body: string; author: { login: string } | null }>;
+        };
+      };
+    };
+  }>(
+    `query($owner:String!,$repo:String!,$pr:Int!){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$pr){
+          reviewThreads(first:100){ nodes{ id isResolved comments(first:50){ nodes{ databaseId path line originalLine body author{login} } } } }
+          reviews(first:50){ nodes{ state body author{login} } }
+        }
+      }
+    }`,
+    { owner, repo, pr: prNumber }
+  );
+
+  const pr = data.repository.pullRequest;
+  const threads: ReviewThread[] = pr.reviewThreads.nodes.map((t) => ({
+    id: t.id,
+    isResolved: t.isResolved,
+    comments: t.comments.nodes.map((c) => ({
+      id: c.databaseId,
+      path: c.path,
+      line: c.line ?? c.originalLine,
+      author: c.author?.login ?? "unknown",
+      body: c.body,
+    })),
+  }));
+  const reviews: ReviewSummary[] = pr.reviews.nodes
+    .filter((r) => r.body && r.body.trim())
+    .map((r) => ({ author: r.author?.login ?? "unknown", state: r.state, body: r.body }));
+
+  return { threads, reviews };
+}
+
+// Reply to an inline review comment thread (REST in_reply_to).
+export async function replyToReviewComment(
+  prNumber: number,
+  commentId: number,
+  body: string
+): Promise<{ id: number; html_url: string }> {
+  return request(`/repos/${owner}/${repo}/pulls/${prNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body, in_reply_to: commentId }),
+  });
+}
+
+// Mark a review thread resolved (GraphQL — no REST equivalent).
+export async function resolveReviewThread(threadId: string): Promise<void> {
+  await graphqlRequest(
+    `mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id isResolved } } }`,
+    { id: threadId }
+  );
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -394,7 +394,7 @@ export async function getPullRequestReview(prNumber: number): Promise<PullReques
         reviews: {
           nodes: Array<{ state: string; body: string; author: { login: string } | null }>;
         };
-      };
+      } | null;
     };
   }>(
     `query($owner:String!,$repo:String!,$pr:Int!){
@@ -409,6 +409,11 @@ export async function getPullRequestReview(prNumber: number): Promise<PullReques
   );
 
   const pr = data.repository.pullRequest;
+  if (!pr) {
+    // GitHub GraphQL returns pullRequest: null (no errors array) for an
+    // unknown PR number — surface a clear message instead of a null deref.
+    throw new Error(`Pull request #${prNumber} not found in ${owner}/${repo}.`);
+  }
   const threads: ReviewThread[] = pr.reviewThreads.nodes.map((t) => ({
     id: t.id,
     isResolved: t.isResolved,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
@@ -21,12 +23,19 @@ import * as plan from "./tools/plan.js";
 import * as linkIssues from "./tools/link_issues.js";
 import * as createPullRequest from "./tools/create_pull_request.js";
 import * as commitAndUpdate from "./tools/commit_and_update.js";
+import * as listPrReviewComments from "./tools/list_pr_review_comments.js";
+import * as replyToReviewComment from "./tools/reply_to_review_comment.js";
+import * as resolveReviewThread from "./tools/resolve_review_thread.js";
 
-const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, plan, linkIssues, createPullRequest, commitAndUpdate];
+import * as addressPrReview from "./prompts/address_pr_review.js";
+
+const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, plan, linkIssues, createPullRequest, commitAndUpdate, listPrReviewComments, replyToReviewComment, resolveReviewThread];
+
+const prompts = [addressPrReview];
 
 const server = new Server(
   { name: "okffs", version: "0.0.1" },
-  { capabilities: { tools: {} } }
+  { capabilities: { tools: {}, prompts: {} } }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -44,6 +53,22 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   }
   const input = tool.inputSchema.parse(req.params.arguments);
   return tool.handler(input as never);
+});
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+  prompts: prompts.map((p) => ({
+    name: p.name,
+    description: p.description,
+    arguments: p.argumentDefs,
+  })),
+}));
+
+server.setRequestHandler(GetPromptRequestSchema, async (req) => {
+  const prompt = prompts.find((p) => p.name === req.params.name);
+  if (!prompt) {
+    throw new Error(`Unknown prompt: ${req.params.name}`);
+  }
+  return prompt.build(req.params.arguments ?? {});
 });
 
 const transport = new StdioServerTransport();

--- a/src/prompts/address_pr_review.ts
+++ b/src/prompts/address_pr_review.ts
@@ -1,0 +1,39 @@
+export const name = "address_pr_review";
+
+export const description =
+  "Read a pull request's review comments, fix the valid ones, reply to each, and post a summary.";
+
+export const argumentDefs = [
+  {
+    name: "pr_number",
+    description: "The pull request number to address review comments for",
+    required: true,
+  },
+];
+
+export function build(args: Record<string, string | undefined>) {
+  const pr = args.pr_number ?? "<pr_number>";
+  const text = [
+    `Address the review feedback on PR #${pr}. Work through these steps:`,
+    ``,
+    `1. Call \`list_pr_review_comments\` for PR #${pr} to read the inline threads and review summaries.`,
+    `2. Triage: decide which comments are valid and in scope. Use your judgment — you don't have to act on every comment, but explain any you intentionally skip.`,
+    `3. Fix the code for the comments you're addressing. Build/verify if the project supports it.`,
+    `4. Commit and push the fixes with \`commit_and_update\`.`,
+    `5. Reply to each addressed thread with \`reply_to_review_comment\` (use the comment id from step 1), briefly noting what you changed and referencing the fix.`,
+    `6. Post an overall summary of the fixes as a PR comment with \`comment_issue\` (pass the PR number — PRs accept issue comments).`,
+    `7. For each addressed thread, call \`resolve_review_thread\` with its thread id. It respects \`OKFFS_RESOLVE_THREADS\`: threads are only actually resolved when that env var is enabled, otherwise they're left for the user to resolve.`,
+    ``,
+    `Keep replies and the summary concise and specific about what changed.`,
+  ].join("\n");
+
+  return {
+    description: `Address review feedback on PR #${pr}`,
+    messages: [
+      {
+        role: "user" as const,
+        content: { type: "text" as const, text },
+      },
+    ],
+  };
+}

--- a/src/tools/list_pr_review_comments.ts
+++ b/src/tools/list_pr_review_comments.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { getPullRequestReview } from "../github.js";
+
+export const name = "list_pr_review_comments";
+
+export const description =
+  "Fetch review feedback for a pull request: inline review comment threads (each with comment ids, file/line, author, body, and resolved/unresolved state) plus overall review summaries. Use this to read PR review comments before addressing them. Typical workflow: read with this tool, fix the code for the valid comments, commit/push with commit_and_update, reply to each addressed thread with reply_to_review_comment, post an overall summary with comment_issue (PRs accept issue comments), and — only if OKFFS_RESOLVE_THREADS is enabled — mark threads resolved with resolve_review_thread.";
+
+export const inputSchema = z.object({
+  pr_number: z.number().int().positive().describe("The pull request number"),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  const { threads, reviews } = await getPullRequestReview(input.pr_number);
+
+  const unresolved = threads.filter((t) => !t.isResolved);
+  const resolved = threads.filter((t) => t.isResolved);
+
+  const parts: string[] = [
+    `PR #${input.pr_number}: ${threads.length} review thread(s) (${unresolved.length} unresolved), ${reviews.length} review summary(ies).`,
+  ];
+
+  const renderThread = (t: (typeof threads)[number]) => {
+    const lines: string[] = [
+      `[${t.isResolved ? "resolved" : "UNRESOLVED"}] thread_id: ${t.id}`,
+    ];
+    t.comments.forEach((c, i) => {
+      const loc = c.path ? `${c.path}${c.line ? `:${c.line}` : ""}` : "(general)";
+      const label = i === 0 ? "comment" : "reply";
+      lines.push(`  • ${label} id:${c.id}  ${loc}  by ${c.author}`);
+      lines.push(`    ${c.body.replace(/\n/g, "\n    ")}`);
+    });
+    return lines.join("\n");
+  };
+
+  if (unresolved.length > 0) {
+    parts.push(`\n## Unresolved threads\n${unresolved.map(renderThread).join("\n\n")}`);
+  }
+  if (resolved.length > 0) {
+    parts.push(`\n## Resolved threads\n${resolved.map(renderThread).join("\n\n")}`);
+  }
+  if (reviews.length > 0) {
+    parts.push(
+      `\n## Review summaries\n${reviews
+        .map((r) => `[${r.author}] ${r.state}\n${r.body}`)
+        .join("\n\n---\n\n")}`
+    );
+  }
+  if (threads.length === 0 && reviews.length === 0) {
+    parts.push("\nNo review comments or summaries found.");
+  }
+
+  return { content: [{ type: "text" as const, text: parts.join("\n") }] };
+}

--- a/src/tools/reply_to_review_comment.ts
+++ b/src/tools/reply_to_review_comment.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { replyToReviewComment } from "../github.js";
+
+export const name = "reply_to_review_comment";
+
+export const description =
+  "Reply to an inline PR review comment thread. Pass the pull request number, the comment id (from list_pr_review_comments), and the reply body. Use after addressing a review comment to record what was changed (e.g. reference the fix commit).";
+
+export const inputSchema = z.object({
+  pr_number: z.number().int().positive().describe("The pull request number"),
+  comment_id: z
+    .number()
+    .int()
+    .positive()
+    .describe("The review comment id to reply to (from list_pr_review_comments)"),
+  body: z.string().describe("Reply body"),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  const reply = await replyToReviewComment(input.pr_number, input.comment_id, input.body);
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Replied to comment #${input.comment_id} on PR #${input.pr_number}: ${reply.html_url}`,
+      },
+    ],
+  };
+}

--- a/src/tools/resolve_review_thread.ts
+++ b/src/tools/resolve_review_thread.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { resolveReviewThread } from "../github.js";
+import { config } from "../config.js";
+
+export const name = "resolve_review_thread";
+
+export const description =
+  "Mark an inline PR review thread as resolved. Pass the thread_id from list_pr_review_comments. Gated by OKFFS_RESOLVE_THREADS: when that env var is not 'true', this tool declines and leaves the thread open for the user to read and resolve manually.";
+
+export const inputSchema = z.object({
+  thread_id: z
+    .string()
+    .describe("The review thread id to resolve (from list_pr_review_comments)"),
+});
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  if (!config.resolveThreads) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text:
+            "Not resolving — OKFFS_RESOLVE_THREADS is not enabled. The thread is left open for you to read and resolve on GitHub. Set OKFFS_RESOLVE_THREADS=true to allow okffs to resolve threads automatically.",
+        },
+      ],
+    };
+  }
+
+  await resolveReviewThread(input.thread_id);
+  return {
+    content: [{ type: "text" as const, text: `Resolved review thread ${input.thread_id}.` }],
+  };
+}


### PR DESCRIPTION
## Summary
Adds an out-of-the-box PR review-response workflow. New tools: list_pr_review_comments (fetch inline threads + review summaries via GraphQL, with comment ids, file/line, author, body, resolved state, and thread ids), reply_to_review_comment (reply to a thread by id), and resolve_review_thread (resolve via GraphQL, gated by the new OKFFS_RESOLVE_THREADS env var — declines unless enabled so threads are left for the user by default). Adds an MCP prompt address_pr_review (surfaced as a slash command) that orchestrates read → triage/fix → commit_and_update → reply per thread → comment_issue summary → optional resolve, and wires up the MCP prompts capability in index.ts. Top-level PR summary comments reuse comment_issue (PRs are issues). Documented in README (tools table + new "Responding to PR reviews" section), .env.example, and CLAUDE.md. Verified live against PR #57 (threads, ids, replies parsed correctly), the resolve guard, and the prompt builder.

## Changes
- chore: init branch for #58
- feat: PR review-response workflow (tools + MCP prompt)

Closes #58