### PR TITLE
Close #62 - add README Changelog section; fix stale OKFFS_EXCLUDE_DOCS example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - Auto-doc entries are now concise title-based one-liners instead of truncated summary dumps; CLAUDE.md and CONTRIBUTING.md are no longer auto-updated (CHANGELOG.md, plus SECURITY.md when relevant, are the only auto-doc targets) ([#60](https://github.com/2b9sa2owa/okffs/issues/60)).
+- Corrected the stale `OKFFS_EXCLUDE_DOCS` example in the README (valid options are `CHANGELOG.md`, `SECURITY.md`) ([#62](https://github.com/2b9sa2owa/okffs/issues/62)).
 
 ### Added
+- A Changelog section in the README linking to Releases and `CHANGELOG.md` ([#62](https://github.com/2b9sa2owa/okffs/issues/62)).
 - PR review-response workflow: new `list_pr_review_comments`, `reply_to_review_comment`, and `resolve_review_thread` tools, plus an `address_pr_review` MCP prompt (slash command) that reads a PR's review comments, fixes them, replies per thread, and posts a summary. Thread resolution is gated by the new `OKFFS_RESOLVE_THREADS` env var (default off) ([#58](https://github.com/2b9sa2owa/okffs/issues/58)).
 - Reduced auth/setup friction: token resolves from `GITHUB_TOKEN` or falls back to `gh auth token`, and owner/repo auto-detect from the `origin` git remote when env vars are unset ([#56](https://github.com/2b9sa2owa/okffs/issues/56)).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This project is being built in phases. See [CLAUDE.md](CLAUDE.md) for the full r
 | 5 | GitHub Projects v2 (optional) | Planned |
 | 6 | Project site — `okffs.g2mk.dev` | Planned |
 
+## Changelog
+
+See [Releases](https://github.com/2b9sa2owa/okffs/releases) for per-version release notes, or [CHANGELOG.md](CHANGELOG.md) for the full history.
+
 ## Usage with Claude Code
 
 Add okffs to any project by creating a `.mcp.json` in the project root:
@@ -122,7 +126,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
    OKFFS_UPDATE_DOCS=false                        # set to true to auto-update project docs on workflow events
    OKFFS_AUTO_PR=false                            # set to true to open a draft PR when a new issue branch is created
    OKFFS_RESOLVE_THREADS=false                    # set to true to let okffs auto-resolve PR review threads after they're addressed
-   OKFFS_EXCLUDE_DOCS=CLAUDE.md,CONTRIBUTING.md   # comma-separated — valid options: CLAUDE.md, SECURITY.md, CONTRIBUTING.md, CHANGELOG.md
+   OKFFS_EXCLUDE_DOCS=SECURITY.md                 # comma-separated — valid options: CHANGELOG.md, SECURITY.md
    ```
 
 4. Build and point your `.mcp.json` at the local build:


### PR DESCRIPTION
Closes #62

Two README fixes (docs-only):

1. **Add a `## Changelog` section** linking to Releases and `CHANGELOG.md` — npm renders only the README, so this gives users a path to release notes.
2. **Fix the stale `OKFFS_EXCLUDE_DOCS` example** in the local-dev env block, which still listed `CLAUDE.md,CONTRIBUTING.md` (dropped from auto-updates in #60). Valid options are now `CHANGELOG.md`, `SECURITY.md`.

Per the #62 decision, CLAUDE.md/CONTRIBUTING.md auto-updates stay dropped (Option A); the separate "intelligently update CLAUDE.md" idea is tracked in #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)