### PR TITLE
chore: prepare MCP Registry publish (server.json + mcpName)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 src/
+server.json
 .env
 .env.example
 .mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-30
+### Added
+- Published to the official MCP Registry (`io.github.neturely/okffs`): added `server.json` and an `mcpName` field to `package.json` for registry package-ownership verification.
+
 ## [0.2.1] - 2026-06-30
 ### Changed
 - Migrated the project to the `neturely` GitHub organization; updated repository, homepage, and documentation links accordingly.
@@ -53,7 +57,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/neturely/okffs/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/neturely/okffs/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/neturely/okffs/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/neturely/okffs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/neturely/okffs/compare/v0.1.6...v0.2.0
 [0.1.6]: https://github.com/neturely/okffs/compare/v0.1.5...v0.1.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neturely/okffs",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.2.1",
+  "version": "0.2.2",
+  "mcpName": "io.github.neturely/okffs",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.neturely/okffs",
+  "title": "okffs",
+  "description": "MCP server connecting Claude Code to GitHub for an issue to branch to PR to close workflow.",
+  "websiteUrl": "https://github.com/neturely/okffs#readme",
+  "repository": {
+    "url": "https://github.com/neturely/okffs",
+    "source": "github"
+  },
+  "version": "0.2.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@neturely/okffs",
+      "version": "0.2.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "GITHUB_TOKEN",
+          "description": "GitHub PAT (fine-grained recommended). Falls back to `gh auth token` if unset.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "GITHUB_OWNER",
+          "description": "Target repo owner. Auto-detected from the git origin remote if unset.",
+          "isRequired": false
+        },
+        {
+          "name": "GITHUB_REPO",
+          "description": "Target repo name. Auto-detected from the git origin remote if unset.",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Repo-side prep to publish okffs to the official MCP Registry as `io.github.neturely/okffs`. okffs was never in the registry, so this is a first-time publish (no migration).

## Changes
- **`server.json`** — registry manifest: name `io.github.neturely/okffs`, npm package `@neturely/okffs`, stdio transport, `GITHUB_*` env vars. Excluded from the npm tarball.
- **`mcpName`** in `package.json` — required so the registry can verify package ownership (it reads this from the published package).
- **v0.2.2** bump + CHANGELOG roll.

Validated: `server.json.name` === `package.json.mcpName`, versions aligned, description ≤100 chars, schema URL reachable, build clean, `server.json` not in tarball.

## Manual follow-up (after merge — security key + browser auth)
1. `npm publish` `@neturely/okffs@0.2.2` (so the published package carries `mcpName`)
2. Install `mcp-publisher`, `mcp-publisher login github` (authorizes the `neturely` namespace), `mcp-publisher publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)