### PR TITLE
ci: auto-publish to MCP Registry on tag (GitHub OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and MCP Registry
 
 on:
   push:
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for mcp-publisher's github-oidc auth (no stored token)
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +25,35 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Resolve package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Publish to npm
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # ---- MCP Registry (io.github.neturely/okffs) ----
+      - name: Sync server.json version to package.json
+        run: |
+          node -e "const fs=require('fs');const v=require('./package.json').version;const s=require('./server.json');s.version=v;s.packages.forEach(p=>p.version=v);fs.writeFileSync('server.json',JSON.stringify(s,null,2)+'\n')"
+
+      - name: Wait for npm to expose mcpName (registry verification reads it)
+        run: |
+          for i in $(seq 1 30); do
+            got="$(npm view "@neturely/okffs@${{ steps.pkg.outputs.version }}" mcpName 2>/dev/null || true)"
+            if [ "$got" = "io.github.neturely/okffs" ]; then echo "mcpName visible ✓"; exit 0; fi
+            echo "waiting for npm propagation ($i/30)..."; sleep 10
+          done
+          echo "::error::mcpName not visible on npm after timeout; registry publish would fail"; exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
Makes future releases one step again: a `vX.Y.Z` tag now publishes **both npm and the MCP Registry**, so no manual `mcp-publisher` run/auth per release.

## How
- **`id-token: write`** permission → `mcp-publisher login github-oidc` authenticates via the workflow's own OIDC identity. `neturely/okffs` maps to the `io.github.neturely/*` namespace, so **no stored registry token** (nothing to expire).
- **Sync `server.json` version from `package.json`** at publish time — no manual `server.json` bump per release.
- **Wait for npm to expose `mcpName`** before the registry publish (the registry's ownership check reads it from the published package; this covers propagation lag — same issue we hit publishing manually).
- npm publish is unchanged (still `NPM_TOKEN`).

## Release flow after this
`prepare_release` → merge develop→main (merge commit) → `git tag vX.Y.Z && git push --tags` → CI publishes npm + registry. Done.

Note: relies on `NPM_TOKEN` having publish rights to the scoped `@neturely` package — worth a test tag to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)