### PR TITLE
Close #81 - Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery ([#81](https://github.com/neturely/okffs/issues/81))
 
 ## [0.2.2] - 2026-06-30
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,4 +23,21 @@ export const config = {
   excludeDocs: process.env.OKFFS_EXCLUDE_DOCS
     ? process.env.OKFFS_EXCLUDE_DOCS.split(",").map((s) => s.trim())
     : [],
+  // ── GitHub Projects v2 (Phase 5) ──────────────────────────────────────────
+  // OKFFS_PROJECT_ENABLED=true — opt-in; surfaces the project column in
+  // list_issues and lets update_project_status run. Zero overhead when unset.
+  projectEnabled: process.env.OKFFS_PROJECT_ENABLED === "true",
+  // OKFFS_PROJECT_ID — the Project's GraphQL node ID (e.g. PVT_kwHO...).
+  projectId: process.env.OKFFS_PROJECT_ID || null,
+  // OKFFS_PROJECT_AUTO_ADD=true — fallback for users without native GitHub board
+  // automation: create_issue adds the new issue to the board. Off by default.
+  projectAutoAdd: process.env.OKFFS_PROJECT_AUTO_ADD === "true",
 };
+
+// Warn once at startup if the feature is half-configured. Non-fatal: the
+// Projects code no-ops when disabled, and every call re-checks projectId.
+if (config.projectEnabled && !config.projectId) {
+  console.warn(
+    "[okffs] OKFFS_PROJECT_ENABLED=true but OKFFS_PROJECT_ID is unset — Projects features are inert until you set the board's GraphQL node ID."
+  );
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -94,7 +94,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-async function graphqlRequest<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+export async function graphqlRequest<T>(query: string, variables: Record<string, unknown>): Promise<T> {
   const res = await fetch(`${BASE}/graphql`, {
     method: "POST",
     headers: {

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,227 @@
+// GitHub Projects v2 integration (Phase 5).
+//
+// Projects v2 has no REST API, so everything here goes through GraphQL, reusing
+// the shared `graphqlRequest` helper from github.ts. Field and single-select
+// option node IDs differ per board, so they are discovered at runtime (and
+// memoized) rather than hardcoded. All calls no-op / throw clearly when the
+// feature is disabled or the token lacks Projects permission.
+
+import { graphqlRequest, owner, repo } from "./github.js";
+import { config } from "./config.js";
+
+export interface ProjectMetadata {
+  // Single-select field ids + their option maps (option name → option id).
+  // Status is expected on any board; Priority is optional.
+  statusFieldId: string | null;
+  statusOptions: Map<string, string>;
+  priorityFieldId: string | null;
+  priorityOptions: Map<string, string>;
+}
+
+// Throw a clear, actionable message when the token can't reach Projects, rather
+// than leaking a raw GraphQL FORBIDDEN blob. Permission errors arrive either as
+// an HTTP 403 or as a 200 with a FORBIDDEN error in the payload.
+async function projectCall<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/\b403\b|FORBIDDEN|not accessible/i.test(msg)) {
+      throw new Error(
+        "[okffs] GitHub denied a Projects API call (403 / forbidden). The token needs Projects access: " +
+          'fine-grained PAT → Organization permissions → "Projects: Read and write"; ' +
+          "classic PAT → the `project` scope. " +
+          `Original error: ${msg}`
+      );
+    }
+    throw err;
+  }
+}
+
+function requireProjectId(): string {
+  if (!config.projectId) {
+    throw new Error(
+      "[okffs] OKFFS_PROJECT_ID is not set — cannot talk to a GitHub Project board. " +
+        "Set it to the board's GraphQL node ID (e.g. PVT_kwHO...)."
+    );
+  }
+  return config.projectId;
+}
+
+let metadataCache: Promise<ProjectMetadata> | null = null;
+
+// Discover the board's single-select fields and options once per process.
+// The promise itself is cached so concurrent callers share one request; on
+// failure the cache is cleared so a later call can retry.
+export function getProjectMetadata(): Promise<ProjectMetadata> {
+  if (!metadataCache) {
+    metadataCache = fetchProjectMetadata().catch((err) => {
+      metadataCache = null;
+      throw err;
+    });
+  }
+  return metadataCache;
+}
+
+async function fetchProjectMetadata(): Promise<ProjectMetadata> {
+  const projectId = requireProjectId();
+  const data = await projectCall(() =>
+    graphqlRequest<{
+      node: {
+        fields: {
+          nodes: Array<{
+            id?: string;
+            name?: string;
+            options?: Array<{ id: string; name: string }>;
+          }>;
+        };
+      } | null;
+    }>(
+      `query($project:ID!){
+        node(id:$project){
+          ... on ProjectV2 {
+            fields(first:50){
+              nodes{
+                ... on ProjectV2SingleSelectField { id name options { id name } }
+              }
+            }
+          }
+        }
+      }`,
+      { project: projectId }
+    )
+  );
+
+  if (!data.node) {
+    throw new Error(
+      `[okffs] Project ${projectId} not found (or not visible to this token). Check OKFFS_PROJECT_ID.`
+    );
+  }
+
+  const meta: ProjectMetadata = {
+    statusFieldId: null,
+    statusOptions: new Map(),
+    priorityFieldId: null,
+    priorityOptions: new Map(),
+  };
+
+  for (const field of data.node.fields.nodes) {
+    // Non-single-select fields come back as empty objects from the inline
+    // fragment — skip anything without a name and options.
+    if (!field.id || !field.name || !field.options) continue;
+    const optionMap = new Map(field.options.map((o) => [o.name, o.id] as const));
+    const name = field.name.toLowerCase();
+    if (name === "status") {
+      meta.statusFieldId = field.id;
+      meta.statusOptions = optionMap;
+    } else if (name === "priority") {
+      meta.priorityFieldId = field.id;
+      meta.priorityOptions = optionMap;
+    }
+  }
+
+  return meta;
+}
+
+// Add an issue (by its GraphQL node id) to the configured board. Returns the
+// project *item* id — distinct from the issue node id, and required to set
+// field values on the item.
+export async function addIssueToProject(issueNodeId: string): Promise<string> {
+  const projectId = requireProjectId();
+  const data = await projectCall(() =>
+    graphqlRequest<{ addProjectV2ItemById: { item: { id: string } } }>(
+      `mutation($project:ID!,$content:ID!){
+        addProjectV2ItemById(input:{projectId:$project,contentId:$content}){ item{ id } }
+      }`,
+      { project: projectId, content: issueNodeId }
+    )
+  );
+  return data.addProjectV2ItemById.item.id;
+}
+
+// Set a single-select field (Status, Priority) on a project item.
+export async function setProjectFieldValue(
+  itemId: string,
+  fieldId: string,
+  optionId: string
+): Promise<void> {
+  const projectId = requireProjectId();
+  await projectCall(() =>
+    graphqlRequest(
+      `mutation($project:ID!,$item:ID!,$field:ID!,$opt:String!){
+        updateProjectV2ItemFieldValue(input:{
+          projectId:$project,itemId:$item,fieldId:$field,
+          value:{ singleSelectOptionId:$opt }
+        }){ projectV2Item{ id } }
+      }`,
+      { project: projectId, item: itemId, field: fieldId, opt: optionId }
+    )
+  );
+}
+
+// Find the project item id for an issue already on the board (null if absent).
+export async function getProjectItemForIssue(issueNumber: number): Promise<string | null> {
+  const projectId = requireProjectId();
+  const data = await projectCall(() =>
+    graphqlRequest<{
+      repository: {
+        issue: {
+          projectItems: { nodes: Array<{ id: string; project: { id: string } }> };
+        } | null;
+      } | null;
+    }>(
+      `query($owner:String!,$repo:String!,$num:Int!){
+        repository(owner:$owner,name:$repo){
+          issue(number:$num){
+            projectItems(first:20){ nodes{ id project{ id } } }
+          }
+        }
+      }`,
+      { owner, repo, num: issueNumber }
+    )
+  );
+  const nodes = data.repository?.issue?.projectItems.nodes ?? [];
+  return nodes.find((n) => n.project.id === projectId)?.id ?? null;
+}
+
+// Map of issue number → current Status column, for list_issues enrichment.
+// Capped at the first 100 board items (matches list_issues' own page size).
+export async function getProjectStatusByIssueNumber(): Promise<Map<number, string>> {
+  const projectId = requireProjectId();
+  const data = await projectCall(() =>
+    graphqlRequest<{
+      node: {
+        items: {
+          nodes: Array<{
+            content: { number?: number } | null;
+            fieldValueByName: { name?: string } | null;
+          }>;
+        };
+      } | null;
+    }>(
+      `query($project:ID!){
+        node(id:$project){
+          ... on ProjectV2 {
+            items(first:100){
+              nodes{
+                content{ ... on Issue { number } }
+                fieldValueByName(name:"Status"){
+                  ... on ProjectV2ItemFieldSingleSelectValue { name }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { project: projectId }
+    )
+  );
+
+  const result = new Map<number, string>();
+  for (const item of data.node?.items.nodes ?? []) {
+    const number = item.content?.number;
+    const status = item.fieldValueByName?.name;
+    if (number != null && status) result.set(number, status);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
Phase 5 foundation for GitHub Projects v2. Exports the shared graphqlRequest helper from github.ts; adds OKFFS_PROJECT_ENABLED / OKFFS_PROJECT_ID / OKFFS_PROJECT_AUTO_ADD config with a non-fatal half-config startup warning; introduces src/projects.ts with memoized runtime discovery of the board's Status/Priority single-select field + option IDs (no hardcoded node IDs), plus addIssueToProject, setProjectFieldValue, getProjectItemForIssue, and getProjectStatusByIssueNumber. Projects GraphQL calls surface a clear [okffs] error on 403/forbidden naming the required token permission (fine-grained: org Projects Read/write; classic: project scope). No behavior change unless the feature is enabled.

## Changes
- chore: init branch for #81
- Add Projects v2 GraphQL foundation: export graphqlRequest from github.ts

## Issue comments

```
### 🔧 Commit update

**Commit:** `42bf586`
**Message:** Add Projects v2 GraphQL foundation: export graphqlRequest from github.ts
**Time:** 2026-07-01T15:04:51.080Z

**Files changed:**
- `src/config.ts`
- `src/github.ts`

**Summary:** Add Projects v2 GraphQL foundation: export graphqlRequest from github.ts; add OKFFS_PROJECT_ENABLED/OKFFS_PROJECT_ID/OKFFS_PROJECT_AUTO_ADD config with a half-config startup warning; new src/projects.ts with memoized runtime field/option discovery (getProjectMetadata), addIssueToProject, setProjectFieldValue, getProjectItemForIssue, getProjectStatusByIssueNumber, and a clear [okffs] 403/forbidden error explaining the required Projects token permission
```


Closes #81