### PR TITLE
Close #82 - Phase 5: add update_project_status tool (Backlog/Ready/In Progress/Review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery ([#81](https://github.com/neturely/okffs/issues/81))
+### Added
+- Phase 5: add update_project_status tool (Backlog/Ready/In Progress/Review) ([#82](https://github.com/neturely/okffs/issues/82))
 
 ## [0.2.2] - 2026-06-30
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,11 +28,12 @@ import * as listPrReviewComments from "./tools/list_pr_review_comments.js";
 import * as replyToReviewComment from "./tools/reply_to_review_comment.js";
 import * as resolveReviewThread from "./tools/resolve_review_thread.js";
 import * as prepareRelease from "./tools/prepare_release.js";
+import * as updateProjectStatus from "./tools/update_project_status.js";
 
 import * as addressPrReview from "./prompts/address_pr_review.js";
 import * as updateGuidance from "./prompts/update_guidance.js";
 
-const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, plan, linkIssues, createPullRequest, commitAndUpdate, listPrReviewComments, replyToReviewComment, resolveReviewThread, prepareRelease];
+const tools = [createIssue, listIssues, closeIssue, deleteIssue, deleteBranch, getIssue, commentIssue, createIssuesFromList, plan, linkIssues, createPullRequest, commitAndUpdate, listPrReviewComments, replyToReviewComment, resolveReviewThread, prepareRelease, updateProjectStatus];
 
 const prompts = [addressPrReview, updateGuidance];
 

--- a/src/tools/update_project_status.ts
+++ b/src/tools/update_project_status.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { config } from "../config.js";
+import { getProjectItemForIssue, getProjectMetadata, setProjectFieldValue } from "../projects.js";
+
+export const name = "update_project_status";
+
+export const description =
+  "Move an issue between GitHub Project board columns: Backlog, Ready, In Progress, or Review. " +
+  "Done is intentionally NOT settable here — it is owned by native GitHub board automation on PR merge / issue close. " +
+  "Drive this conversationally during the dev workflow: after create_issue places an issue on the board, offer to move " +
+  'it to "In Progress" when work starts, and to "Review" when a PR goes up. ' +
+  "Requires OKFFS_PROJECT_ENABLED and the issue to already be on the board.";
+
+const STATUSES = ["Backlog", "Ready", "In Progress", "Review"] as const;
+
+export const inputSchema = z.object({
+  issue: z.number().int().positive().describe("Issue number to move"),
+  status: z
+    .enum(STATUSES)
+    .describe('Target column: "Backlog", "Ready", "In Progress", or "Review" (Done is owned by native automation)'),
+});
+
+const text = (t: string) => ({ content: [{ type: "text" as const, text: t }] });
+
+export async function handler(input: z.infer<typeof inputSchema>) {
+  if (!config.projectEnabled) {
+    return text("OKFFS_PROJECT_ENABLED is not set — project status updates are disabled.");
+  }
+
+  const itemId = await getProjectItemForIssue(input.issue);
+  if (!itemId) {
+    return text(
+      `Issue #${input.issue} is not on the project board. Add it first (create_issue with ` +
+        "OKFFS_PROJECT_AUTO_ADD=true, or add it to the board manually)."
+    );
+  }
+
+  const meta = await getProjectMetadata();
+  if (!meta.statusFieldId) {
+    return text("The board has no Status field — cannot update the column.");
+  }
+
+  const optionId = meta.statusOptions.get(input.status);
+  if (!optionId) {
+    const opts = [...meta.statusOptions.keys()].join(", ") || "none";
+    return text(`The board has no "${input.status}" column. Available columns: ${opts}.`);
+  }
+
+  await setProjectFieldValue(itemId, meta.statusFieldId, optionId);
+  return text(`Issue #${input.issue} moved to "${input.status}".`);
+}


### PR DESCRIPTION
## Summary
Adds the update_project_status tool: moves an issue between the board's Backlog / Ready / In Progress / Review columns via GraphQL. Done is intentionally excluded — native GitHub automation owns it on PR merge / issue close. The tool guards OKFFS_PROJECT_ENABLED, resolves the issue's project item (getProjectItemForIssue) and the target option (getProjectMetadata), and returns clear messages when the feature is disabled, the issue isn't on the board, or the board lacks the requested column. Registered in index.ts. Its description guides the agent to drive transitions conversationally (offer In Progress when work starts, Review when a PR goes up).

## Changes
- chore: init branch for #82
- Merge remote-tracking branch 'origin/develop' into 82-okffs-phase-5-add-updateprojectstatus-tool
- Add update_project_status tool — moves an issue between board columns (B

## Issue comments

```
### 🔧 Commit update

**Commit:** `7ca29d9`
**Message:** Add update_project_status tool — moves an issue between board columns (B
**Time:** 2026-07-01T15:12:44.434Z

**Files changed:**
- `src/index.ts`

**Summary:** Add update_project_status tool — moves an issue between board columns (Backlog/Ready/In Progress/Review) via GraphQL; Done deliberately excluded (owned by native automation). Guards OKFFS_PROJECT_ENABLED, resolves the item via getProjectItemForIssue and the option via getProjectMetadata, with clear messages when disabled, not on board, or the column is missing. Registered in index.ts.
```


Closes #82