### PR TITLE
Close #83 - Phase 5: create_issue auto-add to board + priority field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery ([#81](https://github.com/neturely/okffs/issues/81))
+### Added
+- Phase 5: create_issue auto-add to board + priority field ([#83](https://github.com/neturely/okffs/issues/83))
 
 ## [0.2.2] - 2026-06-30
 ### Added

--- a/src/github.ts
+++ b/src/github.ts
@@ -146,7 +146,7 @@ export async function createIssue(
   assignees?: string[],
   labels?: string[],
   milestone?: number
-): Promise<{ number: number; html_url: string }> {
+): Promise<{ number: number; html_url: string; node_id: string }> {
   return request(`/repos/${owner}/${repo}/issues`, {
     method: "POST",
     body: JSON.stringify({ title, body, assignees, labels, ...(milestone !== undefined && { milestone }) }),

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, buildBranchName, createDraftPullRequest } from "../github.js";
 import { config } from "../config.js";
 import { git, currentBranch } from "../git.js";
+import { addIssueToProject, getProjectMetadata, setProjectFieldValue } from "../projects.js";
 
 export const name = "create_issue";
 
@@ -14,6 +15,9 @@ export const inputSchema = z.object({
   assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
   labels: z.array(z.string()).optional().describe("Labels to apply e.g. bug, feature"),
   milestone: z.number().int().optional().describe("Milestone number to assign"),
+  priority: z.string().optional().describe(
+    "Optional Project board Priority (e.g. High, Medium, Low) — matched against the board's Priority field options. Only applied when OKFFS_PROJECT_AUTO_ADD=true and the board has a Priority field."
+  ),
 });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
@@ -32,6 +36,35 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const updatedBody = `${input.description}\n\n**Branch:** \`${branchName}\``;
   await updateIssueBody(issue.number, updatedBody);
+
+  // Add the issue to the configured Project board (fallback for users without
+  // native board automation). Non-fatal, mirroring the autoPR block below: any
+  // failure warns with an [okffs] prefix and never blocks issue creation.
+  let addedToBoard = false;
+  let priorityApplied: string | null = null;
+  if (config.projectAutoAdd && config.projectEnabled) {
+    try {
+      const itemId = await addIssueToProject(issue.node_id);
+      addedToBoard = true;
+      if (input.priority) {
+        const meta = await getProjectMetadata();
+        const optionId = meta.priorityFieldId
+          ? meta.priorityOptions.get(input.priority)
+          : undefined;
+        if (meta.priorityFieldId && optionId) {
+          await setProjectFieldValue(itemId, meta.priorityFieldId, optionId);
+          priorityApplied = input.priority;
+        } else {
+          const opts = [...meta.priorityOptions.keys()].join(", ") || "none";
+          console.warn(
+            `[okffs] Could not set priority "${input.priority}" — board Priority options are: ${opts}.`
+          );
+        }
+      }
+    } catch (err) {
+      console.warn("[okffs] Failed to add issue to project board:", err instanceof Error ? err.message : err);
+    }
+  }
 
   let draftPRUrl: string | null = null;
   if (config.autoPR) {
@@ -88,12 +121,28 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     lines.push(`Labels: ${resolvedLabels.join(", ")}${source}`);
   }
 
+  if (addedToBoard) {
+    lines.push(
+      `Board: added to the project${priorityApplied ? ` (priority: ${priorityApplied})` : ""}`
+    );
+  }
+
   lines.push(
     ``,
     `To start work:`,
     `  git fetch origin`,
     `  git checkout ${branchName}`,
   );
+
+  // Conversational nudge: prompt the host LLM to offer moving the issue into
+  // the "In Progress" column via update_project_status once work begins.
+  if (addedToBoard) {
+    lines.push(
+      ``,
+      `This issue is on the board in its default column. Want me to move it to "In Progress" and start? ` +
+      `(I can call update_project_status for #${issue.number}.)`
+    );
+  }
 
   if (config.promptForMetadata && !input.assignees && !input.labels) {
     lines.push(


### PR DESCRIPTION
## Summary
create_issue now places new issues on the configured Projects v2 board and sets an initial priority. createIssue() returns the issue node_id; a new optional priority input is matched against the board's discovered Priority options. When OKFFS_PROJECT_AUTO_ADD=true (and the feature is enabled), a non-fatal block (mirroring the existing autoPR pattern) adds the issue to the board and applies priority — any failure warns with an [okffs] prefix and never blocks issue creation. The tool output reports the board add + applied priority and nudges the agent to offer moving the issue to In Progress via update_project_status. No behavior change unless auto-add is enabled.

## Changes
- chore: init branch for #83
- Merge remote-tracking branch 'origin/develop' into 83-okffs-phase-5-createissue-auto-add-to
- create_issue: auto-add new issues to the Project board and set initial p

## Issue comments

```
### 🔧 Commit update

**Commit:** `0b22e62`
**Message:** create_issue: auto-add new issues to the Project board and set initial p
**Time:** 2026-07-01T15:11:22.256Z

**Files changed:**
- `src/github.ts`
- `src/tools/create_issue.ts`

**Summary:** create_issue: auto-add new issues to the Project board and set initial priority. createIssue() now returns node_id; new optional priority input; non-fatal board-add block (mirrors autoPR) that adds the issue when OKFFS_PROJECT_AUTO_ADD=true and applies priority via the discovered Priority option, warning [okffs] on any failure without blocking issue creation; output reports board add + priority and nudges to move to In Progress via update_project_status
```


Closes #83