### PR TITLE
Close #84 - Phase 5: enrich list_issues with current project column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
+- Phase 5: enrich list_issues with current project column ([#84](https://github.com/neturely/okffs/issues/84))
 - Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery ([#81](https://github.com/neturely/okffs/issues/81))
 
 ## [0.2.2] - 2026-06-30

--- a/src/tools/list_issues.ts
+++ b/src/tools/list_issues.ts
@@ -9,6 +9,8 @@ import {
   repo,
   type IssueRelationships,
 } from "../github.js";
+import { config } from "../config.js";
+import { getProjectStatusByIssueNumber } from "../projects.js";
 
 export const name = "list_issues";
 
@@ -19,6 +21,17 @@ export const inputSchema = z.object({});
 
 export async function handler(_input: z.infer<typeof inputSchema>) {
   const [issues, prs] = await Promise.all([listIssues(), listOpenPullRequests()]);
+
+  // Current board column per issue. Non-fatal: if the project fetch fails (e.g.
+  // token lacks Projects permission), the listing still renders without it.
+  let projectStatus = new Map<number, string>();
+  if (config.projectEnabled && config.projectId) {
+    try {
+      projectStatus = await getProjectStatusByIssueNumber();
+    } catch (err) {
+      console.warn("[okffs] Failed to fetch project statuses:", err instanceof Error ? err.message : err);
+    }
+  }
 
   if (issues.length === 0) {
     return {
@@ -58,6 +71,11 @@ export async function handler(_input: z.infer<typeof inputSchema>) {
 
     if (pr) {
       lines.push(`    PR:     #${pr.number} (${pr.draft ? "draft" : "open"})  ${pr.html_url}`);
+    }
+
+    const status = projectStatus.get(issue.number);
+    if (status) {
+      lines.push(`    project: ${status}`);
     }
 
     // Relationships as a small tree under the issue.


### PR DESCRIPTION
## Summary
list_issues now surfaces each issue's current Project board column. When OKFFS_PROJECT_ENABLED (and OKFFS_PROJECT_ID is set), it fetches getProjectStatusByIssueNumber alongside the existing issues/PRs Promise.all and renders a `project: <column>` line per issue. The fetch is non-fatal — if it fails (e.g. token lacks Projects permission) the listing still renders without the column, with an [okffs] warning. Zero extra work when the feature is disabled.

## Changes
- chore: init branch for #84
- Merge remote-tracking branch 'origin/develop' into 84-okffs-phase-5-enrich-listissues-with
- list_issues: surface each issue's current board column. When OKFFS_PROJE

## Issue comments

```
### 🔧 Commit update

**Commit:** `de1ed34`
**Message:** list_issues: surface each issue's current board column. When OKFFS_PROJE
**Time:** 2026-07-01T15:13:56.175Z

**Files changed:**
- `src/tools/list_issues.ts`

**Summary:** list_issues: surface each issue's current board column. When OKFFS_PROJECT_ENABLED (and project id set), fetch getProjectStatusByIssueNumber alongside the existing issues/PRs Promise.all and render a `project: <column>` line per issue. Non-fatal — the listing still renders if the project fetch fails. Zero overhead when disabled.
```


Closes #84