### PR TITLE
Close #85 - Phase 5: document Projects v2 integration (env vars, token scope, conversational flow)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,19 @@ OKFFS_UPDATE_GUIDANCE=false
 
 # Comma-separated filenames to exclude from doc updates (valid: CHANGELOG.md, SECURITY.md)
 OKFFS_EXCLUDE_DOCS=
+
+# ── GitHub Projects v2 (Phase 5) ──────────────────────────────────────────────
+# Opt in to the Projects v2 integration. When enabled, list_issues shows each
+# issue's current board column and the update_project_status tool can move
+# issues between columns (Backlog, Ready, In Progress, Review).
+OKFFS_PROJECT_ENABLED=false
+# The Project's GraphQL node ID (e.g. PVT_kwHO...). Required when enabled.
+OKFFS_PROJECT_ID=
+# Fallback for users WITHOUT native GitHub board automation: create_issue adds
+# each new issue to the board. Leave false if your board already auto-adds issues
+# via GitHub's built-in project workflows.
+OKFFS_PROJECT_AUTO_ADD=false
+#
+# Token permission for Projects v2: fine-grained PAT → Organization permissions →
+# "Projects: Read and write"; classic PAT → the `project` scope. Without it,
+# Projects calls fail with a clear [okffs] 403 error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
+- Phase 5: document Projects v2 integration (env vars, token scope, conversational flow) ([#85](https://github.com/neturely/okffs/issues/85))
 - Phase 5: enrich list_issues with current project column ([#84](https://github.com/neturely/okffs/issues/84))
 - Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery ([#81](https://github.com/neturely/okffs/issues/81))
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - TypeScript MCP server scaffolded.
 - PAT auth via `.env` (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`).
 - `.env` is loaded automatically via `dotenv` from `process.cwd()` — no `--env-file` flag needed in `.mcp.json`.
-- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `plan`, `create_pull_request`, `commit_and_update`, `list_pr_review_comments`, `reply_to_review_comment`, `resolve_review_thread`, `prepare_release`.
+- Tools: `create_issue`, `list_issues`, `close_issue`, `delete_issue`, `delete_branch`, `get_issue`, `comment_issue`, `link_issues`, `create_issues_from_list`, `plan`, `create_pull_request`, `commit_and_update`, `list_pr_review_comments`, `reply_to_review_comment`, `resolve_review_thread`, `prepare_release`, `update_project_status`.
 - Prompts (MCP `prompts` capability, surfaced as slash commands): `address_pr_review` — read a PR's review comments, fix the valid ones, reply per thread, post a summary, and optionally resolve threads; `update_guidance` — review an issue's changes and intelligently maintain the bounded `## Project Guidance (okffs usage)` section of CLAUDE.md to reflect new/changed functionality (substantive, marker-delimited; never touches the user's other content).
 - `create_issue` auto-creates a branch, embeds the branch name in the issue body, applies default assignees/labels from `.env`, infers labels from title/description and merges with `OKFFS_DEFAULT_LABELS`. Supports optional `assignees`, `labels`, `milestone`. If a relationship is mentioned (blocked by, blocking, parent), automatically calls `link_issues` after creation. If `OKFFS_AUTO_PR=true`, pushes an empty init commit to the branch (capturing and restoring the current branch) and opens a draft PR immediately.
 - `create_issues_from_list` accepts a list of tasks and creates all issues + branches in one shot. Two-step confirmation. Per-task `labels`, `assignees`, and `milestone` supported.
@@ -71,6 +71,10 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - `OKFFS_AUTO_PR` — set to `true` to open a draft PR when a new issue branch is created (via `create_issue`). Default `false`.
 - `OKFFS_RESOLVE_THREADS` — set to `true` to let okffs auto-resolve PR review threads after they're addressed (via `resolve_review_thread`). Default `false` — threads are left open for the user to resolve.
 - `OKFFS_UPDATE_GUIDANCE` — set to `true` to have `create_pull_request` nudge the agent to keep CLAUDE.md in sync with new/changed functionality (via the `update_guidance` prompt). Default `false`. The prompt is always available regardless.
+- `update_project_status` moves an issue between GitHub Projects v2 board columns (`Backlog`, `Ready`, `In Progress`, `Review`) via GraphQL. `Done` is intentionally excluded — it is owned by native GitHub board automation on merge/close. Guarded by `OKFFS_PROJECT_ENABLED`; resolves the board's field/option node IDs at runtime (no hardcoding). Driven conversationally: after `create_issue` places an issue on the board, the agent offers to move it to `In Progress` and start.
+- `OKFFS_PROJECT_ENABLED` — set to `true` to enable the Projects v2 integration (`list_issues` shows each issue's board column; `update_project_status` works). Default `false`; zero overhead when unset.
+- `OKFFS_PROJECT_ID` — the Project's GraphQL node ID (e.g. `PVT_kwHO...`). Required when the feature is enabled.
+- `OKFFS_PROJECT_AUTO_ADD` — set to `true` (fallback only) to have `create_issue` add new issues to the board via GraphQL, optionally setting a `priority`. Default `false` — leave off if your board uses GitHub's native auto-add workflow. Non-fatal: failures warn `[okffs]` and never block issue creation. Projects v2 needs a Projects-capable token (fine-grained: org "Projects: Read and write"; classic: `project` scope); missing permission surfaces a clear `[okffs]` 403 error.
 
 ### Phase 2 — Bulk creation ✓ Complete
 
@@ -95,11 +99,14 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - GitHub natively closes the issue on merge via `Closes #N` — no webhook infrastructure needed. Note: this only fires when merging into the repo's default branch. With a `develop`-based workflow (`OKFFS_BASE_BRANCH=develop`), merge to `develop` does not auto-close; use `close_issue`.
 - Edge case: if the branch has no commits ahead of the base branch, a friendly comment is posted instead of erroring.
 
-### Phase 5 — GitHub Projects v2 (optional, later)
+### Phase 5 — GitHub Projects v2 ✓ Complete
 
-- Add issues to a GitHub Project board on creation.
-- Update status fields as work progresses.
-- Requires the GraphQL API.
+- Opt-in via `OKFFS_PROJECT_ENABLED`; org-level board addressed by `OKFFS_PROJECT_ID` (GraphQL node ID). Zero overhead when disabled.
+- Projects v2 has no REST API — all board work goes through GraphQL, reusing the shared `graphqlRequest` helper (exported from `github.ts`). Projects code lives in `src/projects.ts`; field and single-select option node IDs are **discovered at runtime and memoized**, never hardcoded (they differ per board).
+- `create_issue` — when `OKFFS_PROJECT_AUTO_ADD=true`, adds the new issue to the board and optionally sets a `priority` (matched against the board's Priority options). Non-fatal, mirroring the `autoPR` block: any failure warns `[okffs]` and never blocks issue creation. `OKFFS_PROJECT_AUTO_ADD` is a fallback for boards without GitHub's native auto-add workflow.
+- `update_project_status` — moves an issue between `Backlog`, `Ready`, `In Progress`, `Review`. **`Done` is intentionally excluded** — native GitHub board automation owns it on PR merge / issue close (okffs already writes `Closes #N`). Driven conversationally by the agent at the natural workflow moments.
+- `list_issues` — surfaces each issue's current board column (`project: <column>`). Non-fatal: the listing still renders if the Projects fetch fails.
+- Token permission: fine-grained PAT → org "Projects: Read and write"; classic PAT → `project` scope. Missing permission surfaces a clear `[okffs]` 403 error.
 
 ### Phase 6 — Project site
 
@@ -121,7 +128,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - Auth resolution: `GITHUB_TOKEN` if set, otherwise falls back to the GitHub CLI (`gh auth token`). If neither is available, startup fails with a message linking to the one-click PAT page.
 - Repo resolution: `GITHUB_OWNER`/`GITHUB_REPO` if set, otherwise auto-detected by parsing the `origin` git remote of `process.cwd()`. So with `gh` signed in and okffs run inside the target repo, no `.env` is required.
 - Resolution lives in `src/github.ts` (`resolveToken`, `resolveOwnerRepo`); `owner`/`repo` are exported from there and reused (e.g. `docs.ts`) so detected values flow everywhere.
-- Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_IDENTIFIER` (optional project-scoped branch prefix: `{number}-{identifier}-{slug}`), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to open a draft PR at branch-creation time via `create_issue`), `OKFFS_RESOLVE_THREADS` (set to `true` to auto-resolve PR review threads after addressing; default leaves them for the user), `OKFFS_UPDATE_GUIDANCE` (set to `true` to nudge keeping CLAUDE.md in sync with functionality changes at PR time), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CHANGELOG.md`, `SECURITY.md`).
+- Optional: `OKFFS_DEFAULT_ASSIGNEES` (comma-separated), `OKFFS_DEFAULT_LABELS` (comma-separated), `OKFFS_PROMPT_METADATA` (set to `false` to silence the tip), `OKFFS_BASE_BRANCH` (branch to create from; defaults to repo default), `OKFFS_IDENTIFIER` (optional project-scoped branch prefix: `{number}-{identifier}-{slug}`), `OKFFS_UPDATE_DOCS` (set to `true` to enable auto doc updates), `OKFFS_AUTO_PR` (set to `true` to open a draft PR at branch-creation time via `create_issue`), `OKFFS_RESOLVE_THREADS` (set to `true` to auto-resolve PR review threads after addressing; default leaves them for the user), `OKFFS_UPDATE_GUIDANCE` (set to `true` to nudge keeping CLAUDE.md in sync with functionality changes at PR time), `OKFFS_EXCLUDE_DOCS` (comma-separated filenames to exclude from auto-updates — valid options: `CHANGELOG.md`, `SECURITY.md`), `OKFFS_PROJECT_ENABLED` (set to `true` to enable the GitHub Projects v2 integration), `OKFFS_PROJECT_ID` (the board's GraphQL node ID; required when enabled), `OKFFS_PROJECT_AUTO_ADD` (set to `true` as a fallback to have `create_issue` add issues to the board when your board has no native auto-add).
 
 ## Local dev vs published package
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is being built in phases. See [CLAUDE.md](CLAUDE.md) for the full r
 | 2 | Bulk creation — `create_issues_from_list` | **Complete** |
 | 3 | Claude.ai bridge | Skipped — not required |
 | 4 | Auto-close on merge — `create_pull_request`, `commit_and_update` | **Complete** |
-| 5 | GitHub Projects v2 (optional) | Planned |
+| 5 | GitHub Projects v2 (optional) | Done |
 | 6 | Project site — `okffs.g2mk.dev` | Planned |
 
 ## Changelog
@@ -127,6 +127,9 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
    OKFFS_RESOLVE_THREADS=false                    # set to true to let okffs auto-resolve PR review threads after they're addressed
    OKFFS_UPDATE_GUIDANCE=false                    # set to true to nudge keeping CLAUDE.md in sync with functionality changes at PR time
    OKFFS_EXCLUDE_DOCS=SECURITY.md                 # comma-separated — valid options: CHANGELOG.md, SECURITY.md
+   OKFFS_PROJECT_ENABLED=false                    # set to true to enable the GitHub Projects v2 integration
+   OKFFS_PROJECT_ID=                              # the Project's GraphQL node ID (e.g. PVT_kwHO...); required when enabled
+   OKFFS_PROJECT_AUTO_ADD=false                   # fallback: create_issue adds new issues to the board (skip if your board auto-adds natively)
    ```
 
 4. Build and point your `.mcp.json` at the local build:
@@ -164,6 +167,7 @@ No installation needed. Add the `.mcp.json` and `.env` to your project as shown 
 | `reply_to_review_comment` | Replies to an inline PR review comment thread by id. |
 | `resolve_review_thread` | Marks a PR review thread resolved. Gated by `OKFFS_RESOLVE_THREADS` — declines unless that's enabled, leaving threads for you to resolve. |
 | `prepare_release` | Bumps the version (`package.json` + `package-lock.json`), rolls the CHANGELOG (`[Unreleased]` → a dated version section), commits on a release branch, and opens a PR. Two-step confirm; takes an explicit `version` or `bump` level (inferred if omitted). Does **not** tag or publish. |
+| `update_project_status` | Moves an issue between GitHub Project board columns (`Backlog`, `Ready`, `In Progress`, `Review`) via GraphQL. `Done` is intentionally excluded — native GitHub automation owns it on merge/close. Requires `OKFFS_PROJECT_ENABLED`. |
 | `delete_issue` | Closes an issue **and** deletes its matching branch. Destructive — requires `confirmed: true`. |
 | `delete_branch` | Deletes a branch **and** closes its matching issue. Destructive — requires `confirmed: true`. |
 
@@ -204,6 +208,42 @@ Use `OKFFS_EXCLUDE_DOCS` to exclude specific files per repo (valid options: `CHA
 ```env
 OKFFS_EXCLUDE_DOCS=SECURITY.md
 ```
+
+## GitHub Projects v2
+
+okffs can keep a GitHub **Projects v2** board in step with your issue workflow. It's **opt-in** and has zero overhead when off.
+
+Enable it in `.env`:
+
+```
+OKFFS_PROJECT_ENABLED=true
+OKFFS_PROJECT_ID=PVT_kwHO...        # the board's GraphQL node ID
+OKFFS_PROJECT_AUTO_ADD=false        # see "auto-add vs native automation" below
+```
+
+Once enabled:
+
+- **`list_issues`** shows each issue's current board column (e.g. `project: In Progress`).
+- **`update_project_status`** moves an issue between `Backlog`, `Ready`, `In Progress`, and `Review`.
+
+### How Claude drives status transitions
+
+Column moves are **conversational**, not automatic. Claude offers them at the natural moments in the workflow — after `create_issue` puts an issue on the board it asks whether to move it to **In Progress** and start; when a PR goes up it can move the issue to **Review**. You stay in control; okffs just provides the `update_project_status` plumbing.
+
+**`Done` is intentionally not settable** by okffs — it's owned by GitHub's **native board automation** (the built-in "Item closed / PR merged → Done" workflow). Since okffs always writes `Closes #N` into PRs, merging closes the issue and native automation moves the card to Done. This avoids two systems fighting over the terminal state.
+
+### Auto-add vs native automation
+
+`OKFFS_PROJECT_AUTO_ADD` is a **fallback**. GitHub Projects can natively auto-add issues to a board (Project → Workflows → "Auto-add to project"). If you use that, leave `OKFFS_PROJECT_AUTO_ADD=false` — okffs doesn't need to add issues itself. Only set it to `true` if your board has no native auto-add and you want `create_issue` to place new issues on the board (optionally with an initial `priority`).
+
+### Token permission
+
+Projects v2 has no REST API, so okffs uses GraphQL, which needs a Projects-capable token:
+
+- **Fine-grained PAT** → *Organization permissions* → **Projects: Read and write**
+- **Classic PAT** → the **`project`** scope
+
+Without it, Projects calls fail with a clear `[okffs]` 403 error naming exactly what's missing. Reads/writes to an **org-level** board require the token to be able to see that org's projects.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
Documents the Phase 5 GitHub Projects v2 integration. .env.example gains OKFFS_PROJECT_ENABLED / OKFFS_PROJECT_ID / OKFFS_PROJECT_AUTO_ADD with a token-permission note. README: Phase 5 status → Done, the three env vars in the setup block, an update_project_status tool row, and a new "GitHub Projects v2" section explaining the env vars, the auto-add fallback vs native board automation distinction, that Done is owned by native automation, how Claude drives status transitions conversationally, and the required Projects token permission plus the [okffs] 403 error. CLAUDE.md: update_project_status added to the tools line, the three OKFFS_PROJECT_* vars documented, and the Phase 5 build section rewritten as complete. Docs-only — no code changes.

## Changes
- chore: init branch for #85
- Merge remote-tracking branch 'origin/develop' into 85-okffs-phase-5-document-projects-v2
- Document Phase 5 Projects v2 integration. .env.example: OKFFS_PROJECT_EN

## Issue comments

```
### 🔧 Commit update

**Commit:** `01ba8c9`
**Message:** Document Phase 5 Projects v2 integration. .env.example: OKFFS_PROJECT_EN
**Time:** 2026-07-01T15:23:39.980Z

**Files changed:**
- `.env.example`
- `CLAUDE.md`
- `README.md`

**Summary:** Document Phase 5 Projects v2 integration. .env.example: OKFFS_PROJECT_ENABLED/OKFFS_PROJECT_ID/OKFFS_PROJECT_AUTO_ADD with token-permission note. README: status table -> Done, env block, update_project_status tool row, and a new "GitHub Projects v2" section covering the env vars, auto-add-vs-native-automation distinction, Done owned by native automation, conversational status transitions, and the required Projects token permission + [okffs] 403 error. CLAUDE.md: added update_project_status to the tools line, documented the three OKFFS_PROJECT_* vars, and rewrote the Phase 5 build section as complete.
```


Closes #85