### PR TITLE
Close #93 - Phase 5: clearer create_issue warning when Priority is an org Issue Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Phase 5: enrich list_issues with current project column ([#84](https://github.com/neturely/okffs/issues/84))
 - Phase 5: Projects v2 GraphQL foundation — config, projects.ts, field discovery ([#81](https://github.com/neturely/okffs/issues/81))
 ### Added
+- Phase 5: clearer create_issue warning when Priority is an org Issue Field ([#93](https://github.com/neturely/okffs/issues/93))
 - Phase 5: add update_project_status tool (Backlog/Ready/In Progress/Review) ([#82](https://github.com/neturely/okffs/issues/82))
 - Phase 5: create_issue auto-add to board + priority field ([#83](https://github.com/neturely/okffs/issues/83))
 

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -54,10 +54,24 @@ export async function handler(input: z.infer<typeof inputSchema>) {
         if (meta.priorityFieldId && optionId) {
           await setProjectFieldValue(itemId, meta.priorityFieldId, optionId);
           priorityApplied = input.priority;
-        } else {
-          const opts = [...meta.priorityOptions.keys()].join(", ") || "none";
+        } else if (!meta.priorityFieldId) {
           console.warn(
-            `[okffs] Could not set priority "${input.priority}" — board Priority options are: ${opts}.`
+            `[okffs] Priority "${input.priority}" not set: the board has no Priority field.`
+          );
+        } else if (meta.priorityOptions.size === 0) {
+          // Priority field exists but exposes no options via the project API —
+          // the hallmark of a GitHub org-level Issue Field (options live under
+          // organization.issueFields, not on the project single-select field).
+          // Full read/write support is tracked in #91.
+          console.warn(
+            `[okffs] Priority "${input.priority}" not set: the board's Priority field looks like an ` +
+              `org-level Issue Field, whose options aren't settable via the project API yet (see #91). ` +
+              `Set it manually in the board UI for now.`
+          );
+        } else {
+          const opts = [...meta.priorityOptions.keys()].join(", ");
+          console.warn(
+            `[okffs] Could not set priority "${input.priority}" — no matching option. Board Priority options: ${opts}.`
           );
         }
       }


### PR DESCRIPTION
## Summary
Improves the create_issue priority warning. The single generic "board Priority options are: none" message is replaced by three targeted cases: (1) no Priority field on the board; (2) Priority field exists but exposes zero options via the project API — the hallmark of a GitHub org-level Issue Field — which now signposts #91 and tells the user to set priority manually in the board UI; (3) options present but the passed value doesn't match, listing the valid options. Still non-fatal — priority issues never block issue creation. Full org Issue Field read/write support remains tracked in #91.

## Changes
- chore: init branch for #93
- create_issue: clearer priority warning. Split the priority-not-set case

## Issue comments

```
### 🔧 Commit update

**Commit:** `63c1e87`
**Message:** create_issue: clearer priority warning. Split the priority-not-set case 
**Time:** 2026-07-01T15:52:09.799Z

**Files changed:**
- `src/tools/create_issue.ts`

**Summary:** create_issue: clearer priority warning. Split the priority-not-set case into three: no Priority field, Priority field with zero project-visible options (the org-level Issue Field case — signposts #91 and tells the user to set it manually), and options-present-but-no-match. Replaces the single generic "options are: none" message. Still non-fatal.
```


Closes #93