### PR TITLE
ci: bump checkout@v7 + setup-node@v6 (clear Node 20 deprecation)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
       contents: read
       id-token: write   # required for mcp-publisher's github-oidc auth
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
@@ -43,9 +43,9 @@ jobs:
       contents: read
       id-token: write   # required for mcp-publisher's github-oidc auth (no stored token)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Bumps the publish workflow's actions off the deprecated Node 20 runtime: `actions/checkout@v4 → @v7`, `actions/setup-node@v4 → @v6` (both jobs). Clears the deprecation warning seen in the verify run. Usage is basic (checkout + node-version/registry-url), so no config changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)