### PR TITLE
fix: address Copilot review on #140 (pagination hardening + description)

### DIFF
--- a/.changes/unreleased/pr140-pagination-hardening.md
+++ b/.changes/unreleased/pr140-pagination-hardening.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- Harden org Issue Field / Projects queries against pagination truncation: bump the org `issueFields` and per-issue `issueFieldValues` page sizes (and the project `fields` query) so Priority/Effort are reliably found on boards/orgs with many fields, rather than being missed past the first page (PR #140 review). Also corrected the `create_pull_request` tool description to reflect the fragment-based `OKFFS_UPDATE_DOCS` behaviour (it writes a `.changes/unreleased/` fragment, not a direct `CHANGELOG.md` edit).

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -92,7 +92,7 @@ async function fetchProjectMetadata(): Promise<ProjectMetadata> {
       `query($project:ID!){
         node(id:$project){
           ... on ProjectV2 {
-            fields(first:50){
+            fields(first:100){
               nodes{
                 ... on ProjectV2SingleSelectField { id name options { id name } }
               }
@@ -239,7 +239,7 @@ async function fetchOrgIssueField(nameLower: string): Promise<OrgIssueField | nu
     }>(
       `query($org:String!){
         organization(login:$org){
-          issueFields(first:50){
+          issueFields(first:100){
             nodes{
               __typename
               ... on IssueFieldSingleSelect { id name options { id name } }
@@ -401,7 +401,7 @@ export async function getOrgIssueFieldValuesByNumber(): Promise<Map<number, Map<
           issues(first:100,states:OPEN){
             nodes{
               number
-              issueFieldValues(first:10){
+              issueFieldValues(first:50){
                 nodes{
                   __typename
                   ... on IssueFieldSingleSelectValue {

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -19,7 +19,7 @@ import { git, currentBranch } from "../git.js";
 export const name = "create_pull_request";
 
 export const description =
-  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, updates the project docs (CHANGELOG.md always, plus SECURITY.md for security-related changes) and commits them onto the branch before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. Posts a summary comment to the issue.";
+  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, writes a per-issue changelog fragment under .changes/unreleased/ (assembled into CHANGELOG.md at release time by prepare_release — not a direct CHANGELOG.md edit), plus SECURITY.md for security-related changes, and commits them onto the branch before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. Posts a summary comment to the issue.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to create a PR for"),


### PR DESCRIPTION
Addresses the actionable Copilot comments on the 0.4.0 release PR (#140). Targets `develop` so #140 (develop→main) picks these up automatically.

## Fixes
- **`projects.ts` pagination** — org `issueFields` `50→100`, per-issue `issueFieldValues` `10→50`, project `fields` `50→100`. Prevents Priority/Effort being missed past the first page on boards/orgs with many fields.
- **`create_pull_request` description** — corrected the stale 'updates CHANGELOG.md directly' text to describe the fragment-based `OKFFS_UPDATE_DOCS` flow (#105). (My earlier #109 fix predated #105, so it drifted again — Copilot caught it.)

## Not addressed here (deliberate)
- **`.githooks/pre-push` `nas backup` gating** — valid, but pre-existing (from #107) and a personal-infra/security decision, not part of the 0.4.0 feature work. Flagged to the maintainer for a separate call.

Verified: `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)