### PR TITLE
Changelog fragments for 0.5.0

### DIFF
--- a/.changes/unreleased/133-real-board-options-inference.md
+++ b/.changes/unreleased/133-real-board-options-inference.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- `create_issue` now injects the board's **real** Priority/Effort option names into its inference guidance (resolved at tools/list time), so Claude infers against the actual board options — e.g. a `P0/P1/P2` board — instead of the generic `Urgent/High/Medium/Low` scale. Falls back to the generic scale when the board is unreachable or the options can't be read (#133).

--- a/.changes/unreleased/137-org-fields-retry.md
+++ b/.changes/unreleased/137-org-fields-retry.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- The org-level Issue Fields preview API (used for `list_issues` Priority/Effort and `create_issue` option lookup) is now retried up to 3 times with a short backoff on transient failures, making it far less likely to intermittently drop Priority/Effort. Permission errors (403/FORBIDDEN) are still reported immediately without retry (#137).

--- a/.changes/unreleased/142-readme-friendlier.md
+++ b/.changes/unreleased/142-readme-friendlier.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Rewrote the README for a friendlier first read: a plain-language intro and one-step quickstart up front, the internal build-phase "Status" section removed, and the scattered env-var documentation consolidated into a single Configuration reference table. Development setup, publishing, and codebase-search detail moved to CONTRIBUTING.md (#142).

--- a/.changes/unreleased/144-batch-board-placement.md
+++ b/.changes/unreleased/144-batch-board-placement.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- `create_issues_from_list` and `plan` now place each issue on the GitHub Projects v2 board like `create_issue` does — adding it, setting an inferred/default Priority and Effort, and applying `OKFFS_PROJECT_INITIAL_STATUS` — when `OKFFS_PROJECT_AUTO_ADD=true`. Both tools gained per-task `priority`/`effort` params. Board logic is now shared in `src/board.ts` (#144).

--- a/.changes/unreleased/146-surface-board-skips.md
+++ b/.changes/unreleased/146-surface-board-skips.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- Board Priority/Effort/initial-status steps that are skipped or fail are now surfaced in the tool response instead of only being written to the server's stderr (`console.warn`), which the host and user never see. When a field is requested but not applied (e.g. the board's field is an org-level Issue Field needing a classic PAT, or the value has no matching option), `create_issue`, `create_issues_from_list`, and `plan` now print a `⚠` line explaining why — an enabled board step is never silently dropped (#146).


### PR DESCRIPTION
Adds `.changes/unreleased/` fragments for the five issues merged into this release cycle (#133, #137, #142, #144, #146). These were committed via `commit_and_update` without `OKFFS_UPDATE_DOCS`, so no fragments were auto-written; adding them here so `prepare_release` assembles complete 0.5.0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)