### PR TITLE
Address Copilot review on #150 (0.5.0 hardening)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,11 @@ Use conventional commits:
 
 Maintainer only. Requires an npm account with maintainer access to `@neturely/okffs` (published publicly via `publishConfig.access`).
 
-1. **Prepare the release** with the `prepare_release` tool (ask Claude, e.g. *"prepare a release"* or *"prepare release 0.2.0"*). It bumps `package.json` + `package-lock.json`, rolls the CHANGELOG, and opens a release PR. Review and merge it, then merge to `main`.
-2. **Tag and push** the version:
+1. **Prepare the release** with the `prepare_release` tool (ask Claude, e.g. *"prepare a release"* or *"prepare release X.Y.Z"*). It bumps `package.json` + `package-lock.json`, rolls the CHANGELOG, and opens a release PR. Review and merge it, then merge to `main`.
+2. **Tag and push** the version (replace `X.Y.Z` with the release):
    ```bash
-   git tag v0.2.0
-   git push origin v0.2.0
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
    ```
 
 GitHub Actions publishes to npm automatically on semver tags (`v*.*.*`), so **do not run `npm publish` manually** — it would collide with CI. The `NPM_TOKEN` secret must be set in the repository settings. `prepare_release` deliberately stops before tagging so the irreversible publish stays a manual decision.

--- a/src/board.ts
+++ b/src/board.ts
@@ -85,11 +85,18 @@ async function applyBoardSingleSelect(
   // Project-native single-select with resolvable options.
   if (native.options.size > 0) {
     const optionId = native.options.get(value);
-    if (optionId) {
+    if (!optionId) {
+      return skip(`no matching option. Board ${label} options: ${[...native.options.keys()].join(", ")}.`);
+    }
+    // Catch write failures here too — addIssueToBoard's contract is that field
+    // writes never throw, so a failed set must degrade to a surfaced skip rather
+    // than turning a successful board add into a full boardError.
+    try {
       await setProjectFieldValue(itemId, native.fieldId, optionId);
       return { applied: value };
+    } catch (err) {
+      return skip(`write failed — ${err instanceof Error ? err.message : String(err)}`);
     }
-    return skip(`no matching option. Board ${label} options: ${[...native.options.keys()].join(", ")}.`);
   }
   // No options via the project API → it's a GitHub org-level Issue Field.
   if (!config.classicPat) {

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -215,7 +215,8 @@ async function orgFieldCall<T>(fn: () => Promise<T>): Promise<T> {
       }
     }
   }
-  throw lastErr;
+  // Normalize to an Error so callers' `err instanceof Error` handling is reliable.
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
 }
 
 export interface OrgIssueField {

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -212,10 +212,10 @@ export async function handler(input: z.infer<typeof inputSchema>) {
       }
     }
 
-    for (const entry of created) {
+    for (const [i, entry] of created.entries()) {
       try {
         const pr = await createDraftPullRequest(
-          `WIP: #${entry.number} - ${input.tasks[created.indexOf(entry)].title}`,
+          `WIP: #${entry.number} - ${input.tasks[i].title}`,
           `Closes #${entry.number}`,
           entry.branchName,
           defaultBranch
@@ -238,9 +238,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     }
   }
 
-  const results = created.map((entry) => {
+  const results = created.map((entry, i) => {
     const lines = [
-      `#${entry.number} — ${input.tasks[created.indexOf(entry)].title}`,
+      `#${entry.number} — ${input.tasks[i].title}`,
       `  Branch: \`${entry.branchName}\``,
       `  ${entry.html_url}`,
     ];


### PR DESCRIPTION
Resolves the four Copilot findings on the 0.5.0 release PR #150, applied before tagging so they ship in 0.5.0:

- **board.ts** (correctness) — the project-native `setProjectFieldValue` path could throw out of `addIssueToBoard`, contradicting its "field writes never throw" contract and turning a successful board add into a full `boardError`. Now caught and surfaced as a skip, matching the org-field path.
- **projects.ts** — normalize the post-retry `throw lastErr` to an `Error`.
- **plan.ts** — replace O(n²) `created.indexOf(entry)` with the loop index.
- **CONTRIBUTING.md** — placeholder `vX.Y.Z` in publish examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)