### PR TITLE
Close #156 - Auto-create GitHub Release on tag push

### DIFF
--- a/.changes/unreleased/156-publish-yml-create-the-github-release.md
+++ b/.changes/unreleased/156-publish-yml-create-the-github-release.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- publish.yml: create the GitHub Release automatically on stable tags ([#156](https://github.com/neturely/okffs/issues/156))

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write   # write: create the GitHub Release from the pushed tag (#156)
       id-token: write   # required for mcp-publisher's github-oidc auth (no stored token)
     steps:
       - uses: actions/checkout@v7
@@ -86,6 +86,45 @@ jobs:
         run: npm publish --tag "${{ steps.pkg.outputs.dist_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # ---- GitHub Release (all tags; prereleases flagged) — #156 -------------
+      # Create the GitHub Release from the pushed tag so it never has to be done
+      # by hand. Notes come from the matching CHANGELOG.md section, falling back
+      # to auto-generated notes. Idempotent: skips if the release already exists
+      # (a maintainer may have created it manually). Stable → --latest;
+      # prerelease → --prerelease, mirroring the npm dist-tag split above.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ steps.pkg.outputs.version }}"
+          tag="$GITHUB_REF_NAME"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "::notice::Release $tag already exists — skipping creation."
+            exit 0
+          fi
+          # Extract the "## [version]" section from CHANGELOG.md (up to the next
+          # "## [" heading) for the release body.
+          notes="$(awk -v v="$version" '
+            index($0, "## [" v "]") == 1 { f=1; next }
+            f && index($0, "## [") == 1 { exit }
+            f { print }
+          ' CHANGELOG.md)"
+          args=(--title "$tag")
+          if [ -n "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            printf '%s\n' "$notes" > "$RUNNER_TEMP/relnotes.md"
+            args+=(--notes-file "$RUNNER_TEMP/relnotes.md")
+          else
+            echo "::warning::No CHANGELOG section found for $version — using auto-generated notes."
+            args+=(--generate-notes)
+          fi
+          if [ "${{ steps.pkg.outputs.prerelease }}" = "true" ]; then
+            args+=(--prerelease)
+          else
+            args+=(--latest)
+          fi
+          gh release create "$tag" "${args[@]}"
+          echo "::notice::Created GitHub Release $tag."
 
       # ---- MCP Registry (io.github.neturely/okffs) — stable releases only ----
       - name: Sync server.json version to package.json


### PR DESCRIPTION
## Summary
Adds a GitHub Release step to publish.yml: on tag push it creates the release from the matching CHANGELOG.md section (falls back to --generate-notes), titles it with the tag, flags prereleases (--prerelease) vs stable (--latest), and is idempotent. Bumps publish job contents permission to write.

## Changes
- chore: init branch for #156
- ci: create the GitHub Release automatically on tag push (publish.yml). A

## Issue comments

```
### 🔧 Commit update

**Commit:** `5105ca2`
**Message:** ci: create the GitHub Release automatically on tag push (publish.yml). A
**Time:** 2026-07-04T11:18:37.257Z

**Files changed:**
- `.github/workflows/publish.yml`

**Summary:** ci: create the GitHub Release automatically on tag push (publish.yml). Adds a step after the npm publish that extracts the matching CHANGELOG.md section for the release notes (falling back to --generate-notes), creates the release titled with the tag, flags prereleases with --prerelease and marks stable with --latest, and is idempotent (skips if the release already exists). Bumps the publish job's contents permission to write. Closes #156.
```


Closes #156