### PR TITLE
Release 0.5.1

### DIFF
--- a/.changes/unreleased/152-add-okffs-protected-branch-hard-confirmation.md
+++ b/.changes/unreleased/152-add-okffs-protected-branch-hard-confirmation.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Added -->
-- Add OKFFS_PROTECTED_BRANCH — hard confirmation gate before okffs promotes into a protected branch ([#152](https://github.com/neturely/okffs/issues/152))

--- a/.changes/unreleased/154-guidance-agents-using-okffs-should-prefer.md
+++ b/.changes/unreleased/154-guidance-agents-using-okffs-should-prefer.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- Guidance: agents using okffs should prefer its tools/env over raw gh/git (fallback only) ([#154](https://github.com/neturely/okffs/issues/154))

--- a/.changes/unreleased/156-publish-yml-create-the-github-release.md
+++ b/.changes/unreleased/156-publish-yml-create-the-github-release.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Added -->
-- publish.yml: create the GitHub Release automatically on stable tags ([#156](https://github.com/neturely/okffs/issues/156))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-04
+### Added
+- publish.yml: create the GitHub Release automatically on stable tags ([#156](https://github.com/neturely/okffs/issues/156))
+- Add OKFFS_PROTECTED_BRANCH — hard confirmation gate before okffs promotes into a protected branch ([#152](https://github.com/neturely/okffs/issues/152))
+### Changed
+- Guidance: agents using okffs should prefer its tools/env over raw gh/git (fallback only) ([#154](https://github.com/neturely/okffs/issues/154))
+
 ## [0.5.0] - 2026-07-04
 ### Changed
 - Rewrote the README for a friendlier first read: a plain-language intro and one-step quickstart up front, the internal build-phase "Status" section removed, and the scattered env-var documentation consolidated into a single Configuration reference table. Development setup, publishing, and codebase-search detail moved to CONTRIBUTING.md (#142).
@@ -95,7 +102,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/neturely/okffs/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/neturely/okffs/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/neturely/okffs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/neturely/okffs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/neturely/okffs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/neturely/okffs/compare/v0.2.2...v0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neturely/okffs",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "mcpName": "io.github.neturely/okffs",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",


### PR DESCRIPTION
## Release 0.5.1

- Bumped `package.json` and `package-lock.json` to 0.5.1.
- Rolled the CHANGELOG `[Unreleased]` section into `## [0.5.1]` and refreshed the compare links.
- Assembled and removed 3 changelog fragment(s) from `.changes/unreleased/`.

After merging, tag `v0.5.1` and push it — CI (`publish.yml`) publishes to npm on the tag. This PR does not tag or publish.