### PR TITLE
Close #160 - delete tools stop writing changelog fragments

### DIFF
--- a/.changes/unreleased/160-delete-branch-and-delete-issue-write.md
+++ b/.changes/unreleased/160-delete-branch-and-delete-issue-write.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Removed -->
+- delete_branch and delete_issue write changelog fragments for pure cleanup (noise) ([#160](https://github.com/neturely/okffs/issues/160))

--- a/src/tools/delete_branch.ts
+++ b/src/tools/delete_branch.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 import { addIssueComment, deleteBranch, closeIssue } from "../github.js";
-import { config } from "../config.js";
-import { updateProjectDocs } from "../docs.js";
 
 export const name = "delete_branch";
 
@@ -32,14 +30,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   await deleteBranch(input.branch_name);
   await closeIssue(issueNumber);
 
-  if (config.updateDocs) {
-    await updateProjectDocs({
-      trigger: "delete_branch",
-      issueNumber: issueNumber,
-      summary: `Branch \`${input.branch_name}\` deleted and issue #${issueNumber} closed.`,
-      branchName: input.branch_name,
-    });
-  }
+  // No changelog fragment here: deleting a branch is cleanup, not a functionality
+  // change. create_pull_request is the single source of auto-changelog fragments
+  // (matches close_issue's behaviour) — #160.
 
   return {
     content: [{

--- a/src/tools/delete_issue.ts
+++ b/src/tools/delete_issue.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 import { getIssue, addIssueComment, closeIssue, deleteBranch, extractBranchFromBody } from "../github.js";
-import { config } from "../config.js";
-import { updateProjectDocs } from "../docs.js";
 
 export const name = "delete_issue";
 
@@ -35,15 +33,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     await deleteBranch(branchName);
   }
 
-  if (config.updateDocs) {
-    await updateProjectDocs({
-      trigger: "delete_issue",
-      issueNumber: input.issue_number,
-      issueTitle: issue.title,
-      summary: issue.body ? `Deleted: ${issue.title}. ${issue.body.slice(0, 200)}` : `Deleted: ${issue.title}`,
-      branchName: branchName ?? undefined,
-    });
-  }
+  // No changelog fragment here: deleting an issue is cleanup, not a functionality
+  // change. create_pull_request is the single source of auto-changelog fragments
+  // (matches close_issue's behaviour) — #160.
 
   const lines = [`Issue #${input.issue_number} closed.`];
   if (branchName) lines.push(`Branch \`${branchName}\` deleted.`);


### PR DESCRIPTION
## Summary
Removes the updateProjectDocs (changelog-fragment) calls from delete_branch and delete_issue so pure cleanup no longer produces changelog noise; create_pull_request stays the single source of fragments, matching close_issue.

## Changes
- chore: init branch for #160
- fix: delete_branch and delete_issue no longer write changelog fragments

## Issue comments

```
### 🔧 Commit update

**Commit:** `c5a0565`
**Message:** fix: delete_branch and delete_issue no longer write changelog fragments 
**Time:** 2026-07-04T11:50:26.538Z

**Files changed:**
- `src/tools/delete_branch.ts`
- `src/tools/delete_issue.ts`

**Summary:** fix: delete_branch and delete_issue no longer write changelog fragments (#160). Removed the config.updateDocs → updateProjectDocs blocks (and now-unused config/updateProjectDocs imports) from both tools. Deleting a branch/issue is cleanup, not a functionality change; create_pull_request remains the single source of auto-changelog fragments, matching close_issue.
```


Closes #160