### PR TITLE
Close #162 - close_issue cleans up untouched auto-PR drafts

### DIFF
--- a/.changes/unreleased/162-close-issue-leaves-orphaned-empty-draft.md
+++ b/.changes/unreleased/162-close-issue-leaves-orphaned-empty-draft.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- close_issue leaves orphaned empty draft PRs under OKFFS_AUTO_PR ([#162](https://github.com/neturely/okffs/issues/162))

--- a/src/github.ts
+++ b/src/github.ts
@@ -314,6 +314,13 @@ export async function updatePullRequest(
   });
 }
 
+export async function closePullRequest(prNumber: number): Promise<void> {
+  await request(`/repos/${owner}/${repo}/pulls/${prNumber}`, {
+    method: "PATCH",
+    body: JSON.stringify({ state: "closed" }),
+  });
+}
+
 // Mark a draft PR ready for review. The REST update endpoint cannot change the
 // draft flag, so this uses the GraphQL markPullRequestReadyForReview mutation.
 export async function markPullRequestReady(nodeId: string): Promise<void> {

--- a/src/tools/close_issue.ts
+++ b/src/tools/close_issue.ts
@@ -1,5 +1,17 @@
 import { z } from "zod";
-import { closeIssue, getIssue, addIssueComment, extractBranchFromBody, owner, repo } from "../github.js";
+import {
+  closeIssue,
+  getIssue,
+  addIssueComment,
+  extractBranchFromBody,
+  getOpenPullRequestForBranch,
+  getBranchCommits,
+  getDefaultBranch,
+  closePullRequest,
+  deleteBranch,
+  owner,
+  repo,
+} from "../github.js";
 import { config } from "../config.js";
 
 export const name = "close_issue";
@@ -10,12 +22,53 @@ export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to close"),
 });
 
+// A branch is "untouched" when it carries no real work — either no commits ahead
+// of base, or only okffs's empty init commit (create_issue under OKFFS_AUTO_PR
+// pushes `chore: init branch for #N` so the branch diverges enough to open a
+// draft PR). Any other commit means real work, so we must not clean it up.
+const INIT_COMMIT_RE = /^chore: init branch for #\d+/;
+function isUntouchedBranch(commits: Array<{ commit: { message: string } }>): boolean {
+  return commits.every((c) => INIT_COMMIT_RE.test(c.commit.message));
+}
+
 export async function handler(input: z.infer<typeof inputSchema>) {
   const issue = await getIssue(input.issue_number);
   const branchName = extractBranchFromBody(issue.body);
 
   await closeIssue(input.issue_number);
 
+  // Under OKFFS_AUTO_PR, create_issue opens a draft PR at branch-creation time.
+  // If the issue is closed with no work done, that empty draft PR + branch would
+  // linger (#162). Clean them up — but ONLY when it's a *draft* PR over an
+  // untouched branch. A ready PR, or any branch with real commits, is left alone.
+  let cleanedUp = false;
+  if (branchName && config.autoPR) {
+    try {
+      const pr = await getOpenPullRequestForBranch(branchName);
+      if (pr && pr.draft) {
+        const base = await getDefaultBranch();
+        const commits = await getBranchCommits(branchName, base);
+        if (isUntouchedBranch(commits)) {
+          await closePullRequest(pr.number);
+          await deleteBranch(branchName);
+          await addIssueComment(
+            input.issue_number,
+            `Issue closed with no work on \`${branchName}\` — closed the empty draft PR #${pr.number} and deleted the branch.`
+          );
+          cleanedUp = true;
+        }
+      }
+    } catch (err) {
+      // Non-fatal: the issue is closed regardless; cleanup is best-effort.
+      console.warn(
+        `[okffs] Failed to clean up auto-PR for #${input.issue_number}:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+
+  // Without OKFFS_AUTO_PR there's no draft PR to reconcile; if a branch exists,
+  // just note that it's left untouched (unchanged behaviour).
   if (branchName && !config.autoPR) {
     const comment = [
       `Issue closed. Branch \`${branchName}\` remains open — https://github.com/${owner}/${repo}/tree/${branchName}`,
@@ -29,7 +82,8 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   // single source of auto-changelog entries — firing here too produced
   // duplicates (the PR already logged the change).
 
+  const note = cleanedUp ? " Empty draft PR and branch cleaned up." : "";
   return {
-    content: [{ type: "text" as const, text: `Issue #${input.issue_number} closed.\n\n💡 Tip: run /clear to reset Claude Code context and save tokens before starting the next issue.` }],
+    content: [{ type: "text" as const, text: `Issue #${input.issue_number} closed.${note}\n\n💡 Tip: run /clear to reset Claude Code context and save tokens before starting the next issue.` }],
   };
 }


### PR DESCRIPTION
## Summary
close_issue now cleans up an untouched OKFFS_AUTO_PR draft: adds a closePullRequest helper and, on close, closes the draft PR + deletes the branch when the branch has no real work (only okffs's init commit). Ready PRs and branches with real commits are never touched. Verified live end-to-end.

## Changes
- chore: init branch for #162
- Merge branch 'develop' into 162-okffs-closeissue-leaves-orphaned-empty-draft
- fix: close_issue cleans up an untouched OKFFS_AUTO_PR draft (#162). Adds

## Issue comments

```
### 🔧 Commit update

**Commit:** `eb03c44`
**Message:** fix: close_issue cleans up an untouched OKFFS_AUTO_PR draft (#162). Adds
**Time:** 2026-07-04T11:53:53.535Z

**Files changed:**
- `src/github.ts`
- `src/tools/close_issue.ts`

**Summary:** fix: close_issue cleans up an untouched OKFFS_AUTO_PR draft (#162). Adds closePullRequest(number) helper to github.ts. When closing an issue under OKFFS_AUTO_PR, if the branch has an open DRAFT PR and no real work (every commit is okffs's `chore: init branch` commit, or none), close the draft PR and delete the branch with a comment. A ready PR or any branch with real commits is left untouched; the non-auto-PR informational comment is unchanged. Verified live: closing a throwaway issue closed its draft PR and deleted the branch.
```


Closes #162