### PR TITLE
Reflect close_issue auto-PR cleanup in its description

### DIFF
--- a/src/tools/close_issue.ts
+++ b/src/tools/close_issue.ts
@@ -16,7 +16,8 @@ import { config } from "../config.js";
 
 export const name = "close_issue";
 
-export const description = "Close a GitHub issue by issue number.";
+export const description =
+  "Close a GitHub issue by issue number. Under OKFFS_AUTO_PR, if the issue's branch still has only an untouched auto-created draft PR (no real commits beyond okffs's init commit), that empty draft PR is also closed and the branch deleted. A ready PR, or any branch with real work, is left untouched.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to close"),


### PR DESCRIPTION
Addresses the low-confidence Copilot note on #159: `close_issue`'s description didn't mention the new conditional cleanup (closes an empty auto-PR draft + deletes the untouched branch under OKFFS_AUTO_PR). Refines #162, unreleased in 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)