### PR TITLE
Close #169 - MCP server instructions

### DIFF
--- a/.changes/unreleased/169-provide-mcp-server-instructions-so-agents.md
+++ b/.changes/unreleased/169-provide-mcp-server-instructions-so-agents.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- Provide MCP server `instructions` so agents prefer okffs tools and adopt new features on upgrade ([#169](https://github.com/neturely/okffs/issues/169))

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,26 @@ const version = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8")
 ).version;
 
+// Server-level instructions: the MCP `initialize` result carries this string and
+// hosts (Claude Code, etc.) surface it to the agent every session. It ships with
+// the package version, so upgrading okffs automatically updates the guidance the
+// agent sees — this is how new tools/behaviour get adopted instead of the agent
+// defaulting to raw git/gh (#169). Keep it tight: it's always-on context. This is
+// the machine-visible counterpart to the human-facing README/CLAUDE.md guidance.
+const SERVER_INSTRUCTIONS = `okffs owns the GitHub issue → branch → PR → merge → close workflow (plus, when enabled, a GitHub Projects v2 board and releases). Prefer okffs tools for these actions over raw git/gh/GraphQL: okffs authenticates with GITHUB_TOKEN (use a classic PAT here if org-level Issue Fields are involved) before falling back to the gh CLI, and honours its OKFFS_* env toggles — so hand-rolling git/gh often uses the wrong token or skips okffs conventions.
+
+Common action → tool:
+- Start work: create_issue (also creates the linked branch and writes the **Branch:** line that create_pull_request/commit_and_update rely on). Many at once: create_issues_from_list or plan.
+- Progress: commit_and_update (stage + commit + push + issue comment). Open/finalize a PR: create_pull_request (always adds Closes #N).
+- Board: create_issue sets an inferred priority/effort; move columns with update_project_status (Backlog/Ready/In Progress/Review — Done is GitHub's own automation).
+- PR review: list_pr_review_comments → fix → reply_to_review_comment → resolve_review_thread (honours OKFFS_RESOLVE_THREADS); or the /okffs:address_pr_review prompt.
+- Release: prepare_release (it does NOT tag or publish).
+
+Rules: never merge, tag, or publish into OKFFS_PROTECTED_BRANCH autonomously — hand back to the user for sign-off. Destructive tools (delete_issue, delete_branch) require confirmed: true (call once to preview, again to act).`;
+
 const server = new Server(
   { name: "okffs", version },
-  { capabilities: { tools: {}, prompts: {} } }
+  { capabilities: { tools: {}, prompts: {} }, instructions: SERVER_INSTRUCTIONS }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({


### PR DESCRIPTION
## Summary
Sets the MCP Server `instructions` field with a concise operating brief (prefer okffs tools over raw git/gh, classic-PAT-first auth, action→tool pointers, protected-branch + destructive-tool rules). Ships with the package version so upgrades auto-update the agent-facing guidance. Verified the initialize response returns the instructions.

## Changes
- chore: init branch for #169
- feat: provide MCP server instructions so hosts steer agents to okffs too

## Issue comments

```
### 🔧 Commit update

**Commit:** `aeef9b5`
**Message:** feat: provide MCP server instructions so hosts steer agents to okffs too
**Time:** 2026-07-04T15:48:45.084Z

**Files changed:**
- `src/index.ts`

**Summary:** feat: provide MCP server instructions so hosts steer agents to okffs tools (#169). Sets the Server `instructions` field (ServerOptions) with a concise operating brief: prefer okffs tools over raw git/gh/GraphQL, GITHUB_TOKEN/classic-PAT-first auth, action→tool pointers (create_issue owns the branch link, commit_and_update, create_pull_request, update_project_status, review-thread tools, prepare_release), and the rules (never merge/tag/publish into OKFFS_PROTECTED_BRANCH autonomously; destructive tools need confirmed:true). Ships with the package version, so upgrades auto-update the guidance the agent sees. Verified: initialize response returns the 1409-char instructions string.
```


Closes #169