### PR TITLE
Release 0.5.2

### DIFF
--- a/.changes/unreleased/169-provide-mcp-server-instructions-so-agents.md
+++ b/.changes/unreleased/169-provide-mcp-server-instructions-so-agents.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Added -->
-- Provide MCP server `instructions` so agents prefer okffs tools and adopt new features on upgrade ([#169](https://github.com/neturely/okffs/issues/169))

--- a/.changes/unreleased/171-add-a-tool-to-set-board.md
+++ b/.changes/unreleased/171-add-a-tool-to-set-board.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Added -->
-- Add a tool to set board Priority/Effort (and status) on an existing issue ([#171](https://github.com/neturely/okffs/issues/171))

--- a/.changes/unreleased/173-create-pull-request-fails-for-issues.md
+++ b/.changes/unreleased/173-create-pull-request-fails-for-issues.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Added -->
-- create_pull_request fails for issues whose branch wasn't created by okffs (missing **Branch:** link) ([#173](https://github.com/neturely/okffs/issues/173))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-07-04
+### Added
+- create_pull_request fails for issues whose branch wasn't created by okffs (missing **Branch:** link) ([#173](https://github.com/neturely/okffs/issues/173))
+- Add a tool to set board Priority/Effort (and status) on an existing issue ([#171](https://github.com/neturely/okffs/issues/171))
+- Provide MCP server `instructions` so agents prefer okffs tools and adopt new features on upgrade ([#169](https://github.com/neturely/okffs/issues/169))
+
 ## [0.5.1] - 2026-07-04
 ### Added
 - publish.yml: create the GitHub Release automatically on stable tags ([#156](https://github.com/neturely/okffs/issues/156))
@@ -105,7 +111,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/neturely/okffs/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/neturely/okffs/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/neturely/okffs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/neturely/okffs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/neturely/okffs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/neturely/okffs/compare/v0.3.0...v0.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neturely/okffs",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "mcpName": "io.github.neturely/okffs",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",


### PR DESCRIPTION
## Release 0.5.2

- Bumped `package.json` and `package-lock.json` to 0.5.2.
- Rolled the CHANGELOG `[Unreleased]` section into `## [0.5.2]` and refreshed the compare links.
- Assembled and removed 3 changelog fragment(s) from `.changes/unreleased/`.

After merging, tag `v0.5.2` and push it — CI (`publish.yml`) publishes to npm on the tag. This PR does not tag or publish.