### PR TITLE
Address Copilot review on #179 (0.5.2 polish)

### DIFF
--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -40,11 +40,13 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   // calls resolve it automatically (#173).
   if (!branchName) {
     const current = currentBranch();
-    const inferred = current && new RegExp(`^${input.issue_number}-`).test(current) ? current : null;
+    const inferred = current && current.startsWith(`${input.issue_number}-`) ? current : null;
     const fallback = input.branch ?? inferred;
     if (fallback) {
       branchName = fallback;
-      const base = (issue.body ?? "").trim();
+      // trimEnd only — trimming both ends could strip leading whitespace the user
+      // intentionally put in the issue body.
+      const base = (issue.body ?? "").trimEnd();
       const newBody = base ? `${base}\n\n**Branch:** \`${branchName}\`` : `**Branch:** \`${branchName}\``;
       try {
         await updateIssueBody(input.issue_number, newBody);

--- a/src/tools/set_issue_fields.ts
+++ b/src/tools/set_issue_fields.ts
@@ -29,7 +29,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const issue = await getIssue(input.issue_number);
 
-  let result;
+  let result: Awaited<ReturnType<typeof addIssueToBoard>>;
   try {
     // addIssueToBoard adds the issue to the board (idempotent — returns the
     // existing item if already present) and sets Priority/Effort via the shared,


### PR DESCRIPTION
Three Copilot findings on the develop→main gate PR #179:
- set_issue_fields: explicit type for `result` (was evolving-any; compiled fine, but clearer).
- create_pull_request: `startsWith` instead of a constructed RegExp; `trimEnd` instead of `trim` when backfilling the **Branch:** line (preserve leading body whitespace).

Refines unreleased 0.5.2 code — no changelog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)