### PR TITLE
Close #190 - Address Copilot review on promote_branch (#187): match open PR by head+base, drop unused import, fix stale comment

### DIFF
--- a/.changes/unreleased/190-address-copilot-review-on-promote-branch.md
+++ b/.changes/unreleased/190-address-copilot-review-on-promote-branch.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- Address Copilot review on promote_branch (#187): match open PR by head+base, drop unused import, fix stale comment ([#190](https://github.com/neturely/okffs/issues/190))

--- a/src/github.ts
+++ b/src/github.ts
@@ -304,12 +304,17 @@ export async function requestReviewers(prNumber: number, reviewers: string[]): P
 }
 
 // Find the open PR (if any) whose head is the given branch. Used to reuse a
-// draft PR created up front by create_issue under OKFFS_AUTO_PR=true.
+// draft PR created up front by create_issue under OKFFS_AUTO_PR=true. Pass
+// `base` to also filter by target branch — required for long-lived heads like
+// `develop`, which can have open PRs into several bases (promote_branch), so
+// matching on head alone could return the wrong PR.
 export async function getOpenPullRequestForBranch(
-  branch: string
+  branch: string,
+  base?: string
 ): Promise<{ number: number; html_url: string; node_id: string; draft: boolean } | null> {
+  const baseParam = base ? `&base=${base}` : "";
   const prs = await request<Array<{ number: number; html_url: string; node_id: string; draft: boolean }>>(
-    `/repos/${owner}/${repo}/pulls?head=${owner}:${branch}&state=open&per_page=1`
+    `/repos/${owner}/${repo}/pulls?head=${owner}:${branch}${baseParam}&state=open&per_page=1`
   );
   return prs.length > 0 ? prs[0] : null;
 }

--- a/src/tools/promote_branch.ts
+++ b/src/tools/promote_branch.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import {
-  getDefaultBranch,
   getRepoDefaultBranch,
   getBranchCommits,
   createPullRequest,
@@ -42,9 +41,11 @@ export const inputSchema = z.object({
 const text = (t: string) => ({ content: [{ type: "text" as const, text: t }] });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
-  // head defaults to the integration branch (OKFFS_BASE_BRANCH). getDefaultBranch()
-  // returns it when set, otherwise the repo default — which is the promotion
-  // *target*, not a source, so require an explicit head in that case.
+  // head defaults to the integration branch (OKFFS_BASE_BRANCH). We read
+  // config.baseBranch directly rather than getDefaultBranch(), because that
+  // helper falls back to the repo default branch — which is the promotion
+  // *target*, not a source. If neither an explicit head nor OKFFS_BASE_BRANCH
+  // is set, require the caller to pass one.
   const head = input.head ?? config.baseBranch;
   if (!head) {
     return text(
@@ -80,9 +81,11 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     changes,
   ].join("\n");
 
-  // Reuse an already-open promotion PR for this head rather than erroring — GitHub
-  // permits only one open PR per head→base pair.
-  const existing = await getOpenPullRequestForBranch(head);
+  // Reuse an already-open promotion PR for this head→base rather than erroring —
+  // GitHub permits only one open PR per head→base pair. Match on base too: a
+  // long-lived head like `develop` can have open PRs into several bases, so
+  // head-only matching could reuse/overwrite the wrong PR.
+  const existing = await getOpenPullRequestForBranch(head, base);
   let pr: { number: number; html_url: string; node_id: string };
   let action: string;
   if (existing) {


### PR DESCRIPTION
## Summary
Addresses Copilot's 3 review comments on the develop→main promotion PR #187, all in src/tools/promote_branch.ts: (1) Real bug — promote_branch reused an existing open PR matched by head only, which for a long-lived head like develop could return/overwrite a PR into a different base. getOpenPullRequestForBranch now accepts an optional base param (adds &base= to the pulls query; backward-compatible for the existing create_pull_request caller), and promote_branch passes base so matching is head+base. (2) Removed the unused getDefaultBranch import. (3) Reworded the head-default comment to describe the actual config.baseBranch logic rather than getDefaultBranch(). Once merged into develop, PR #187 picks these up.

## Changes
- chore: init branch for #190
- fix: address Copilot review on promote_branch (#187). (1) match an exist

## Issue comments

```
### 🔧 Commit update

**Commit:** `26e0757`
**Message:** fix: address Copilot review on promote_branch (#187). (1) match an exist
**Time:** 2026-07-05T13:39:38.546Z

**Files changed:**
- `src/github.ts`
- `src/tools/promote_branch.ts`

**Summary:** fix: address Copilot review on promote_branch (#187). (1) match an existing open PR by head AND base — getOpenPullRequestForBranch now takes an optional base param that adds &base= to the query; promote_branch passes base so a long-lived head like develop can't reuse/overwrite a PR into a different base. (2) remove the unused getDefaultBranch import. (3) reword the head-default comment to match the actual config.baseBranch logic.
```


Closes #190