### PR TITLE
Close #196 - Reorganise env vars into labelled groups across .env.example and README (and fix stale/missing entries)

### DIFF
--- a/.changes/unreleased/196-reorganise-env-vars-into-labelled-groups.md
+++ b/.changes/unreleased/196-reorganise-env-vars-into-labelled-groups.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- Reorganise env vars into labelled groups across .env.example and README (and fix stale/missing entries) ([#196](https://github.com/neturely/okffs/issues/196))

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
-# GitHub Configuration
-#
-# Token: set GITHUB_TOKEN, or leave it blank to fall back to the GitHub CLI
+# okffs configuration — copy to .env and fill in.
+# .env is git-ignored and loaded automatically from the directory okffs runs in.
+# Everything below GitHub connection is OPTIONAL; each shows its default.
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. GitHub connection
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Auth: set GITHUB_TOKEN, or leave it blank to fall back to the GitHub CLI
 # (`gh auth login`). Two ways to create a token:
 #   - Fine-grained PAT (recommended, least privilege): Issues, Contents,
 #     Pull requests (read/write), Metadata (read), Administration (read/write)
@@ -8,14 +14,18 @@
 #   - Classic PAT (quickest, but broad `repo` scope across all your repos):
 #     https://github.com/settings/tokens/new?scopes=repo&description=okffs
 GITHUB_TOKEN=
-#
+
 # Repository: optional — auto-detected from the `origin` git remote of the
 # directory okffs runs in. Set these only to override the detected values.
 GITHUB_OWNER=
 GITHUB_REPO=
 
-# Branch to create issues from. Defaults to repo default branch if not set.
-OKFFS_BASE_BRANCH=main
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. Branching & pull requests
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Branch new issue branches are created from. Defaults to the repo default branch.
+OKFFS_BASE_BRANCH=
 
 # A branch okffs must never autonomously merge, tag, or publish into (e.g. main).
 # It governs *merging*, not PR *creation*: okffs will freely open a PR targeting
@@ -29,82 +39,108 @@ OKFFS_PROTECTED_BRANCH=
 # {issue-number}-{identifier}-{slug} instead of {issue-number}-{slug}
 OKFFS_IDENTIFIER=
 
-# Optional defaults applied to every new issue
-OKFFS_PROMPT_METADATA=true
-OKFFS_DEFAULT_ASSIGNEES=your-github-username
-OKFFS_DEFAULT_LABELS=feature,bug
-# Priority for a new issue when create_issue isn't given one (must match a board
-# Priority option, e.g. Urgent/High/Medium/Low). Needs a Priority field on the
-# board — a project-native field, or an org Issue Field with OKFFS_CLASSIC_PAT=true.
+# Open a draft PR at branch-creation time (via create_issue). Default false.
+OKFFS_AUTO_PR=false
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. Issue defaults & inference
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Applied to every new issue (comma-separated). Labels merge with inferred ones.
+OKFFS_DEFAULT_ASSIGNEES=
+OKFFS_DEFAULT_LABELS=
+
+# Board Priority/Effort fallback for a new issue when none is inferred or given
+# (must match a board option, e.g. Urgent/High/Medium/Low). Needs a Priority/Effort
+# field on the board — project-native, or an org Issue Field with OKFFS_CLASSIC_PAT.
 OKFFS_DEFAULT_PRIORITY=
-# Effort for a new issue when create_issue isn't given one (same rules as
-# OKFFS_DEFAULT_PRIORITY, for the board's Effort field, e.g. High/Medium/Low).
 OKFFS_DEFAULT_EFFORT=
+
 # Let Claude infer a priority/effort for each new issue from the task itself
-# (default on). It falls back to the OKFFS_DEFAULT_* values when it can't judge.
-# Set to false to turn the inference off (only an explicit value or the default).
+# (default on). Falls back to the OKFFS_DEFAULT_* values when it can't judge.
+# Set to false to turn the inference instruction off.
 OKFFS_INFER_PRIORITY=true
 OKFFS_INFER_EFFORT=true
 
-# Set to true to automatically update project docs (CHANGELOG.md etc.) on workflow events
-OKFFS_UPDATE_DOCS=false
+# Set false to silence the assignees/labels metadata tip. Default true.
+OKFFS_PROMPT_METADATA=true
 
-# Set to true to automatically create a PR when closing an issue
-OKFFS_AUTO_PR=false
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. PR review
+# ══════════════════════════════════════════════════════════════════════════════
 
-# Set to true to let okffs auto-resolve PR review threads after they're
-# addressed. Default false: threads are left open for you to read and resolve.
+# Let okffs auto-resolve PR review threads once addressed (via resolve_review_thread).
+# Default false: threads are left open for you to read and resolve.
 OKFFS_RESOLVE_THREADS=false
 
-# Set to true to have create_pull_request nudge the agent to keep CLAUDE.md in
-# sync with new/changed functionality (via the update_guidance prompt). Default
-# false. The update_guidance slash command is available regardless.
-OKFFS_UPDATE_GUIDANCE=false
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. Docs & changelog
+# ══════════════════════════════════════════════════════════════════════════════
 
-# Comma-separated filenames to exclude from doc updates (valid: CHANGELOG.md, SECURITY.md)
+# Auto-write doc updates onto the branch at create_pull_request time. Default false.
+# Writes a per-issue CHANGELOG fragment under .changes/unreleased/ (assembled by
+# prepare_release), plus SECURITY.md for security changes. CLAUDE.md, CONTRIBUTING.md
+# and README.md are intentionally left for you to maintain.
+OKFFS_UPDATE_DOCS=false
+
+# Comma-separated filenames to exclude from doc updates (valid: CHANGELOG.md, SECURITY.md).
 OKFFS_EXCLUDE_DOCS=
 
-# ── GitHub Projects v2 (Phase 5) ──────────────────────────────────────────────
+# Nudge create_pull_request to have Claude keep CLAUDE.md's okffs-owned guidance
+# section in sync with new/changed functionality (via the update_guidance prompt).
+# Default false. The update_guidance slash command is available regardless.
+OKFFS_UPDATE_GUIDANCE=false
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. GitHub Projects v2 (board)
+# ══════════════════════════════════════════════════════════════════════════════
+
 # Opt in to the Projects v2 integration. When enabled, list_issues shows each
-# issue's current board column and the update_project_status tool can move
-# issues between columns (Backlog, Ready, In Progress, Review).
+# issue's board column and update_project_status can move issues between columns
+# (Backlog, Ready, In Progress, Review). Default false; zero overhead when unset.
 OKFFS_PROJECT_ENABLED=false
+
 # The Project's GraphQL node ID (e.g. PVT_kwHO...). Required when enabled.
 OKFFS_PROJECT_ID=
-# Fallback for users WITHOUT native GitHub board automation: create_issue adds
-# each new issue to the board. Leave false if your board already auto-adds issues
-# via GitHub's built-in project workflows.
+
+# Fallback for boards WITHOUT GitHub's native auto-add workflow: create_issue adds
+# each new issue to the board. Leave false if your board already auto-adds.
+# Projects v2 needs a Projects-capable token: fine-grained PAT → Organization
+# permissions → "Projects: Read and write"; classic PAT → the `project` scope.
 OKFFS_PROJECT_AUTO_ADD=false
-#
-# Token permission for Projects v2: fine-grained PAT → Organization permissions →
-# "Projects: Read and write"; classic PAT → the `project` scope. Without it,
-# Projects calls fail with a clear [okffs] 403 error.
-#
+
+# Board Status column a freshly auto-added issue should land in (e.g. Backlog).
+# Applied after the draft PR so it wins over GitHub's linked-PR "In Progress"
+# promotion. Unset = leave the board's own automation in charge.
+OKFFS_PROJECT_INITIAL_STATUS=
+
 # Set true ONLY if GITHUB_TOKEN is a classic PAT with the `admin:org` scope. This
-# unlocks setting a Priority that is a GitHub org-level Issue Field (options under
-# organization.issueFields), which fine-grained PATs cannot reach. Leave false
-# otherwise — okffs will skip that path and tell you to set Priority in the UI.
+# unlocks setting a Priority/Effort that is a GitHub org-level Issue Field (options
+# under organization.issueFields), which fine-grained PATs cannot reach. Leave false
+# otherwise — okffs skips that path and tells you to set it in the UI.
 # ⚠️ SECURITY: a classic `admin:org` token is broad (all your repos + org admin).
 # Only enable this if you accept that tradeoff across every repo this token is in.
 OKFFS_CLASSIC_PAT=false
 
-# ── Branch promotion (promote_branch) ─────────────────────────────────────────
-# promote_branch opens the issue-less develop→main (base→protected) promotion PR
+# ══════════════════════════════════════════════════════════════════════════════
+# 7. Branch promotion & releases (promote_branch)
+# ══════════════════════════════════════════════════════════════════════════════
+# promote_branch opens the issue-less base→protected promotion PR (e.g. develop→main)
 # and, when Projects is enabled, adds the PR itself to the board as a card.
-#
+
 # Board Status column the promotion PR card should land in (e.g. Review). Unset =
 # leave it to the board's own automation. Needs OKFFS_PROJECT_ENABLED.
 OKFFS_PROMOTION_STATUS=
+
 # Comma-separated reviewers to request on the promotion PR — e.g. GitHub Copilot
-# code review (`copilot-pull-request-reviewer[bot]`, the develop→main review
-# convention). Unset = request none. Only acted on when OKFFS_PROMOTION_AUTO_REVIEW
-# is true. Best-effort: a failure warns and is surfaced, but never blocks the PR.
+# code review (`copilot-pull-request-reviewer[bot]`, the develop→main convention).
+# Unset = request none. Only acted on when OKFFS_PROMOTION_AUTO_REVIEW is true.
 OKFFS_PROMOTION_REVIEWERS=
+
 # Explicit opt-in to auto-request the reviewers above on the gate PR. Default false.
-# When true, they are requested ONLY when the gate PR is first created (never on
+# When true, they're requested ONLY when the gate PR is first created (never on
 # re-runs), so a reviewer isn't re-triggered repeatedly. Re-review after new commits
 # is a manual step.
 # ⚠️ COST: GitHub Copilot code review is a paid feature — with a billable reviewer,
-# enabling this incurs a charge for each newly-created promotion PR. Leave false if
-# you'd rather request reviews manually.
+# enabling this incurs a charge for each newly-created promotion PR.
 OKFFS_PROMOTION_AUTO_REVIEW=false

--- a/README.md
+++ b/README.md
@@ -126,7 +126,18 @@ GITHUB_REPO=your-repo-name
 
 ### Optional settings
 
-All optional; unset unless noted. See [`.env.example`](.env.example) for a copyable template.
+All optional; unset unless noted. Grouped by concern — the same groups appear in [`.env.example`](.env.example), a copyable template. (`GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` are covered under [Setup](#setup) above.)
+
+**Branching & pull requests**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OKFFS_BASE_BRANCH` | repo default | Branch new issue branches are created from. |
+| `OKFFS_PROTECTED_BRANCH` | — | A branch okffs must never autonomously **merge**, tag, or publish into (e.g. `main`). Governs *merging*, not PR *creation*: okffs will freely **open** a PR targeting it (opening is safe — the merge is already gated by branch protection + your manual merge) and just adds a reminder that the merge/tag stay with you. `prepare_release` flags merging/tagging into it as a manual, user-gated step. |
+| `OKFFS_IDENTIFIER` | — | Prefix for branch names: `{number}-{identifier}-{slug}`. |
+| `OKFFS_AUTO_PR` | `false` | Open a draft PR when a new issue branch is created. |
+
+**Issue defaults & inference**
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
@@ -135,19 +146,38 @@ All optional; unset unless noted. See [`.env.example`](.env.example) for a copya
 | `OKFFS_DEFAULT_PRIORITY` / `OKFFS_DEFAULT_EFFORT` | — | Board Priority/Effort fallback when none is inferred or given. |
 | `OKFFS_INFER_PRIORITY` / `OKFFS_INFER_EFFORT` | `true` | Let Claude infer priority/effort from the task. |
 | `OKFFS_PROMPT_METADATA` | `true` | Set `false` to hide the assignees/labels tip. |
-| `OKFFS_BASE_BRANCH` | repo default | Branch new issue branches are created from. |
-| `OKFFS_PROTECTED_BRANCH` | — | A branch okffs must never promote into without explicit user confirmation (e.g. `main`). `create_pull_request` refuses to target it without `confirmed: true`; `prepare_release` flags merging/tagging into it as a manual, user-gated step. |
-| `OKFFS_IDENTIFIER` | — | Prefix for branch names: `{number}-{identifier}-{slug}`. |
-| `OKFFS_AUTO_PR` | `false` | Open a draft PR when a new issue branch is created. |
+
+**PR review**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
 | `OKFFS_RESOLVE_THREADS` | `false` | Auto-resolve PR review threads after they're addressed. |
-| `OKFFS_UPDATE_GUIDANCE` | `false` | Nudge Claude to keep `CLAUDE.md` in sync at PR time. |
+
+**Docs & changelog**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
 | `OKFFS_UPDATE_DOCS` | `false` | Auto-write CHANGELOG/SECURITY updates on `create_pull_request`. |
 | `OKFFS_EXCLUDE_DOCS` | — | Comma-separated docs to skip (`CHANGELOG.md`, `SECURITY.md`). |
+| `OKFFS_UPDATE_GUIDANCE` | `false` | Nudge Claude to keep `CLAUDE.md` in sync at PR time. |
+
+**GitHub Projects v2 (board)**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
 | `OKFFS_PROJECT_ENABLED` | `false` | Enable the GitHub Projects v2 integration. |
 | `OKFFS_PROJECT_ID` | — | The board's GraphQL node ID (required when enabled). |
 | `OKFFS_PROJECT_AUTO_ADD` | `false` | Add new issues to the board (fallback when the board has no native auto-add). |
 | `OKFFS_PROJECT_INITIAL_STATUS` | — | Column a freshly added issue lands in (e.g. `Backlog`). |
 | `OKFFS_CLASSIC_PAT` | `false` | Set `true` only with a classic `admin:org` PAT — enables org-level Issue Field Priority/Effort (broad token; security tradeoff). |
+
+**Branch promotion & releases** (`promote_branch`)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OKFFS_PROMOTION_STATUS` | — | Board Status column the promotion PR card lands in (e.g. `Review`). Needs `OKFFS_PROJECT_ENABLED`. |
+| `OKFFS_PROMOTION_REVIEWERS` | — | Comma-separated reviewers to request on the gate PR (e.g. `copilot-pull-request-reviewer[bot]`). Only acted on when `OKFFS_PROMOTION_AUTO_REVIEW=true`. |
+| `OKFFS_PROMOTION_AUTO_REVIEW` | `false` | Opt in to auto-request those reviewers, **on gate-PR creation only** (never on re-runs). **⚠️ Cost:** Copilot code review is billable, so this charges per newly-created promotion PR. |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
Reorganises the env-var surface for readability. .env.example is rewritten into 7 titled groups — (1) GitHub connection, (2) Branching & pull requests, (3) Issue defaults & inference, (4) PR review, (5) Docs & changelog, (6) GitHub Projects v2 (board), (7) Branch promotion & releases — each variable with a concise description and the security/cost callouts preserved. The README's flat env table is split into matching grouped sub-tables. Also fixes the stale OKFFS_PROTECTED_BRANCH description (dropped the pre-#181 'refuses without confirmed:true' wording; it governs merging, not PR creation) and adds the previously-missing OKFFS_PROMOTION_* group to the README. Verified all 26 env vars the code reads are present in .env.example.

## Changes
- chore: init branch for #196
- docs: reorganise env vars into 7 labelled groups across .env.example and

## Issue comments

```
### 🔧 Commit update

**Commit:** `5b4f16c`
**Message:** docs: reorganise env vars into 7 labelled groups across .env.example and
**Time:** 2026-07-05T14:51:29.293Z

**Files changed:**
- `.env.example`
- `README.md`

**Summary:** docs: reorganise env vars into 7 labelled groups across .env.example and README. .env.example rewritten with titled sections (GitHub connection; Branching & PRs; Issue defaults & inference; PR review; Docs & changelog; Projects v2; Branch promotion & releases), each var with a short description; README env table split into matching grouped sub-tables. Also fixed the stale OKFFS_PROTECTED_BRANCH description (removed the pre-#181 'refuses without confirmed:true' wording) and added the previously-missing OKFFS_PROMOTION_* vars to the README. Verified all 26 code-read env vars are present in .env.example.
```


Closes #196