### PR TITLE
Close #205 - create_pull_request: opt-in draft/empty-branch mode to backfill a PR for a branch with no commits

### DIFF
--- a/.changes/unreleased/205-create-pull-request-opt-in-draft.md
+++ b/.changes/unreleased/205-create-pull-request-opt-in-draft.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- create_pull_request: opt-in draft/empty-branch mode to backfill a PR for a branch with no commits ([#205](https://github.com/neturely/okffs/issues/205))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - `OKFFS_AUTO_PR` no longer triggers a PR on close — the draft PR is opened at branch-creation time by `create_issue`. To accept the draft PR immediately, `create_issue` first pushes an empty init commit so the branch diverges from base.
 - `commit_and_update` tool — stages all changes, generates a conventional commit message, commits, pushes to the current branch, and posts a rich progress comment to the linked issue.
 - GitHub natively closes the issue on merge via `Closes #N` — no webhook infrastructure needed. Note: this only fires when merging into the repo's default branch. With a `develop`-based workflow (`OKFFS_BASE_BRANCH=develop`), merge to `develop` does not auto-close; use `close_issue`.
-- Edge case: if the branch has no commits ahead of the base branch, a friendly comment is posted instead of erroring.
+- Edge case: if the branch has no commits ahead of the base branch, a friendly comment is posted instead of erroring — **unless** `allow_empty: true` is passed, in which case okffs pushes an empty init commit to diverge the branch and opens a **draft** tracking PR (the same empty-init-commit mechanism `create_issue` uses under `OKFFS_AUTO_PR`, factored into a shared `pushEmptyInitCommit` helper). Opt-in per call — use it to backfill a PR onto a branch that was created empty (#205).
 
 ### Phase 5 — GitHub Projects v2 ✓ Complete
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Claude infers labels (`bug`, `enhancement`, …) from the title and description 
 | `comment_issue` | Posts a comment — handy for logging what a branch did. |
 | `link_issues` | Links two issues (`blocked_by`, `blocking`, `parent`), stored under a `## Relationships` section. |
 | `close_issue` | Closes an issue and tips you to `/clear` before the next one. |
-| `create_pull_request` | Opens a PR for an issue branch — generates the title/body, pushes the branch, always includes `Closes #N`, and comments back. Can write changelog fragments when `OKFFS_UPDATE_DOCS=true`. |
+| `create_pull_request` | Opens a PR for an issue branch — generates the title/body, pushes the branch, always includes `Closes #N`, and comments back. Can write changelog fragments when `OKFFS_UPDATE_DOCS=true`. Pass `allow_empty: true` to backfill a **draft** tracking PR on a branch with no commits (pushes an empty init commit to diverge it). |
 | `commit_and_update` | Stages, commits (message from your `hint` or the diff), pushes, and posts a progress comment to the issue. |
 | `list_pr_review_comments` | Fetches a PR's inline review threads and summaries. |
 | `reply_to_review_comment` | Replies to an inline review thread by id. |

--- a/src/git.ts
+++ b/src/git.ts
@@ -22,3 +22,33 @@ export function currentBranch(): string | null {
     return null;
   }
 }
+
+/**
+ * Push an empty init commit to `branchName` so it diverges from base and GitHub
+ * will accept a (draft) PR for it. Fetches, checks the branch out, commits
+ * `chore: init branch for #N`, and pushes — always restoring the caller's
+ * original branch afterward (even on failure). Throws if any step through the
+ * push fails, so callers can decide whether to proceed or surface an error.
+ *
+ * Shared by create_issue's OKFFS_AUTO_PR flow and create_pull_request's
+ * allow_empty backfill (#205) so the "diverge an empty branch" behaviour lives
+ * in exactly one place.
+ */
+export function pushEmptyInitCommit(branchName: string, issueNumber: number): void {
+  const previousBranch = currentBranch();
+  try {
+    git(["fetch", "origin"]);
+    git(["checkout", branchName]);
+    git(["commit", "--allow-empty", "-m", `chore: init branch for #${issueNumber}`]);
+    git(["push", "origin", branchName]);
+  } finally {
+    // Always restore the caller's original branch, even if a step above failed.
+    if (previousBranch && previousBranch !== branchName) {
+      try {
+        git(["checkout", previousBranch]);
+      } catch (err) {
+        console.warn("[okffs] Failed to restore branch:", err instanceof Error ? err.message : err);
+      }
+    }
+  }
+}

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, buildBranchName, createDraftPullRequest } from "../github.js";
 import { config } from "../config.js";
-import { git, currentBranch } from "../git.js";
+import { pushEmptyInitCommit } from "../git.js";
 import {
   boardAutoAddEnabled,
   addIssueToBoard,
@@ -140,23 +140,11 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   if (config.autoPR) {
     // Push an empty init commit so the branch diverges from base, allowing
     // GitHub to accept a draft PR immediately. Only needed for the auto-PR flow.
-    const previousBranch = currentBranch();
+    // Shared with create_pull_request's allow_empty backfill (#205).
     try {
-      git(["fetch", "origin"]);
-      git(["checkout", branchName]);
-      git(["commit", "--allow-empty", "-m", `chore: init branch for #${issue.number}`]);
-      git(["push", "origin", branchName]);
+      pushEmptyInitCommit(branchName, issue.number);
     } catch (err) {
       console.warn("[okffs] Failed to push init commit:", err instanceof Error ? err.message : err);
-    } finally {
-      // Always restore the caller's original branch, even if a step above failed.
-      if (previousBranch && previousBranch !== branchName) {
-        try {
-          git(["checkout", previousBranch]);
-        } catch (err) {
-          console.warn("[okffs] Failed to restore branch:", err instanceof Error ? err.message : err);
-        }
-      }
     }
 
     try {

--- a/src/tools/create_pull_request.ts
+++ b/src/tools/create_pull_request.ts
@@ -6,6 +6,7 @@ import {
   getBranchCommits,
   getIssueComments,
   createPullRequest,
+  createDraftPullRequest,
   getOpenPullRequestForBranch,
   updatePullRequest,
   markPullRequestReady,
@@ -15,17 +16,18 @@ import {
 } from "../github.js";
 import { config } from "../config.js";
 import { updateProjectDocs } from "../docs.js";
-import { git, currentBranch } from "../git.js";
+import { git, currentBranch, pushEmptyInitCommit } from "../git.js";
 
 export const name = "create_pull_request";
 
 export const description =
-  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, writes a per-issue changelog fragment under .changes/unreleased/ (assembled into CHANGELOG.md at release time by prepare_release — not a direct CHANGELOG.md edit), plus SECURITY.md for security-related changes, and commits them onto the branch before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. Posts a summary comment to the issue. If the issue has no okffs-created branch link (no **Branch:** line — e.g. a pre-okffs issue or a hand-made branch), pass an explicit branch, or check out a branch named {issue-number}-… and okffs infers it; either way it backfills the **Branch:** line. If the PR targets OKFFS_PROTECTED_BRANCH, okffs still opens it (opening is safe and reversible) and adds a reminder that the merge/tag stay with the user — OKFFS_PROTECTED_BRANCH governs autonomous merging, never PR creation.";
+  "Create a pull request for the current issue branch. Reads the issue, its comments, and commits to generate a PR title and body. Always includes Closes #N. If OKFFS_UPDATE_DOCS is true, writes a per-issue changelog fragment under .changes/unreleased/ (assembled into CHANGELOG.md at release time by prepare_release — not a direct CHANGELOG.md edit), plus SECURITY.md for security-related changes, and commits them onto the branch before creating the PR. If a PR already exists for the branch (e.g. a draft opened by create_issue under OKFFS_AUTO_PR=true), it is updated and marked ready for review instead of erroring. By default, a branch with no commits ahead of base is refused (a PR needs a diff); pass allow_empty: true to instead push an empty init commit so the branch diverges and open a **draft** tracking PR — the same mechanism create_issue uses under OKFFS_AUTO_PR, for backfilling a PR onto a branch that was created empty. Posts a summary comment to the issue. If the issue has no okffs-created branch link (no **Branch:** line — e.g. a pre-okffs issue or a hand-made branch), pass an explicit branch, or check out a branch named {issue-number}-… and okffs infers it; either way it backfills the **Branch:** line. If the PR targets OKFFS_PROTECTED_BRANCH, okffs still opens it (opening is safe and reversible) and adds a reminder that the merge/tag stay with the user — OKFFS_PROTECTED_BRANCH governs autonomous merging, never PR creation.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to create a PR for"),
   summary: z.string().optional().describe("Optional summary of what was done — used in PR body and issue comment"),
   branch: z.string().optional().describe("Branch to open the PR from, for issues whose branch okffs didn't create (no **Branch:** line in the body). Usually unnecessary — okffs-created issues carry the link, and a checked-out branch named {issue-number}-… is inferred automatically. When used, okffs backfills the **Branch:** line onto the issue."),
+  allow_empty: z.boolean().optional().describe("When the branch has no commits ahead of base, push an empty init commit so it diverges and open a DRAFT tracking PR instead of refusing. Opt-in (default false) — use to backfill a PR onto a branch that was created empty. Ignored when the branch already has commits."),
 });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
@@ -94,17 +96,40 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     }
   }
 
-  const commits = await getBranchCommits(branchName, baseBranch);
+  let commits = await getBranchCommits(branchName, baseBranch);
   const comments = await getIssueComments(input.issue_number);
 
+  // Whether this is a backfilled tracking PR (empty branch + allow_empty). Such
+  // PRs are opened as drafts — there's no real work to review yet.
+  let draftMode = false;
+
   if (commits.length === 0) {
-    await addIssueComment(
-      input.issue_number,
-      `PR not created — branch \`${branchName}\` has no commits ahead of \`${baseBranch}\`. Push commits to the branch first, then create the PR.`
-    );
-    return {
-      content: [{ type: "text" as const, text: `PR not created — branch \`${branchName}\` has no commits ahead of \`${baseBranch}\`. Push commits first.` }],
-    };
+    if (!input.allow_empty) {
+      await addIssueComment(
+        input.issue_number,
+        `PR not created — branch \`${branchName}\` has no commits ahead of \`${baseBranch}\`. Push commits to the branch first, or pass \`allow_empty: true\` to open a draft tracking PR.`
+      );
+      return {
+        content: [{ type: "text" as const, text: `PR not created — branch \`${branchName}\` has no commits ahead of \`${baseBranch}\`. Push commits first, or pass allow_empty: true for a draft tracking PR.` }],
+      };
+    }
+    // allow_empty: push an empty init commit so the branch diverges from base,
+    // then open a draft PR — the same mechanism create_issue uses under
+    // OKFFS_AUTO_PR (shared helper), applied to an already-created empty branch.
+    try {
+      pushEmptyInitCommit(branchName, input.issue_number);
+    } catch (err) {
+      await addIssueComment(
+        input.issue_number,
+        `PR not created — branch \`${branchName}\` is empty and okffs could not push an init commit to diverge it from \`${baseBranch}\`. Push a commit manually, then retry.`
+      );
+      return {
+        content: [{ type: "text" as const, text: `PR not created — could not push an empty init commit to \`${branchName}\`: ${err instanceof Error ? err.message : String(err)}` }],
+      };
+    }
+    draftMode = true;
+    // Re-read so the PR body's Changes section reflects the new init commit.
+    commits = await getBranchCommits(branchName, baseBranch);
   }
 
   const title = `Close #${input.issue_number} - ${issue.title}`;
@@ -238,6 +263,11 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     }
     pr = { number: existing.number, html_url: existing.html_url };
     action = existing.draft ? "finalized (marked ready)" : "updated";
+  } else if (draftMode) {
+    // Empty-branch backfill — open a draft tracking PR (createDraftPullRequest
+    // returns just number + html_url, which is all we surface below).
+    pr = await createDraftPullRequest(title, body, branchName, baseBranch);
+    action = "created (draft tracking PR)";
   } else {
     pr = await createPullRequest(title, body, branchName, baseBranch);
     action = "created";


### PR DESCRIPTION
## Summary
Adds an opt-in allow_empty mode to create_pull_request. Default behaviour (refuse a PR on a branch with no commits ahead of base) is unchanged; with allow_empty: true, okffs pushes an empty init commit to diverge the branch and opens a DRAFT tracking PR — exactly the mechanism create_issue uses under OKFFS_AUTO_PR. That dance is factored into a shared git.ts pushEmptyInitCommit helper (captures/restores the caller's branch, throws on failure), and create_issue's AUTO_PR block now reuses it rather than duplicating. Verified live: the helper diverges an empty branch 0→1 with the chore: init commit, pushes, and restores the caller's branch (scratch branch, cleaned up). Docs: CLAUDE.md, README. No new env var — allow_empty is a per-call param.

## Changes
- chore: init branch for #205
- create_pull_request: opt-in allow_empty draft/empty-branch mode. Factor

Closes #205