### PR TITLE
Close #218 - Address #217 review: allow clearing milestone in update_issue + accurate auth wording

### DIFF
--- a/.changes/unreleased/218-address-217-review-allow-clearing-milestone.md
+++ b/.changes/unreleased/218-address-217-review-allow-clearing-milestone.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- Address #217 review: allow clearing milestone in update_issue + accurate auth wording ([#218](https://github.com/neturely/okffs/issues/218))

--- a/src/tools/update_issue.ts
+++ b/src/tools/update_issue.ts
@@ -6,11 +6,12 @@ export const name = "update_issue";
 export const description =
   "Mutate the core fields of an EXISTING GitHub issue — title, assignees, labels, milestone, and/or body. " +
   "create_issue only sets these at creation time; this is how you change them afterward (e.g. rename an issue, " +
-  "add or change an assignee) without dropping to raw `gh issue edit`. Uses the configured GITHUB_TOKEN so the " +
-  "edit has the right identity and scopes. Pass only the fields you want to change — omitted fields are left " +
-  "untouched. NOTE: labels and assignees REPLACE the whole set (they do not merge with the current values), so " +
-  "pass the complete desired list; an empty array [] clears them. For board Priority/Effort use set_issue_fields, " +
-  "and for the board Status column use update_project_status — those are not issue fields.";
+  "add or change an assignee) without dropping to raw `gh issue edit`. Authenticates with okffs's configured token " +
+  "(GITHUB_TOKEN, or the gh CLI fallback when it's unset) and applies okffs conventions. Pass only the fields you " +
+  "want to change — omitted fields are left untouched. NOTE: labels and assignees REPLACE the whole set (they do " +
+  "not merge with the current values), so pass the complete desired list; an empty array [] clears them, and " +
+  "milestone: null clears the milestone. For board Priority/Effort use set_issue_fields, and for the board Status " +
+  "column use update_project_status — those are not issue fields.";
 
 export const inputSchema = z.object({
   issue_number: z.number().int().positive().describe("The issue number to update"),
@@ -18,7 +19,7 @@ export const inputSchema = z.object({
   body: z.string().optional().describe("New issue body. Replaces the existing body — pass the full content, not a fragment."),
   assignees: z.array(z.string()).optional().describe("GitHub usernames to assign. REPLACES the current assignees (not merged); [] clears them."),
   labels: z.array(z.string()).optional().describe("Labels to apply. REPLACES the current labels (not merged); [] clears them."),
-  milestone: z.number().int().positive().optional().describe("Milestone number to assign"),
+  milestone: z.number().int().positive().nullable().optional().describe("Milestone number to assign, or null to clear the milestone."),
 });
 
 const text = (t: string) => ({ content: [{ type: "text" as const, text: t }] });
@@ -47,7 +48,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const lines = provided.map((k) => {
     const v = fields[k];
-    const shown = Array.isArray(v) ? (v.length ? v.join(", ") : "(cleared)") : String(v);
+    const shown = Array.isArray(v)
+      ? (v.length ? v.join(", ") : "(cleared)")
+      : v === null ? "(cleared)" : String(v);
     return `  ${k} → ${shown}`;
   });
 


### PR DESCRIPTION
## Summary
Addresses Copilot's review on the v0.7.0 promotion PR #217 (comments on update_issue.ts from #203): (1) the schema now accepts milestone: null so a milestone can be cleared (the updateIssue helper already supported it), (2) a cleared milestone renders as (cleared) instead of the literal "null", consistent with labels/assignees, and (3) the tool description is corrected to say it authenticates with the configured token (GITHUB_TOKEN, or the gh CLI fallback) rather than over-promising GITHUB_TOKEN. Declined Copilot's suggested guard that would refuse unless GITHUB_TOKEN is set — the gh fallback is okffs's intentional global auth model used by every tool. Verified: milestone: null is accepted and renders (cleared).

## Changes
- chore: init branch for #218
- Address #217 Copilot review on update_issue: allow milestone:null to cle

## Issue comments

```
### 🔧 Commit update

**Commit:** `9a0c58b`
**Message:** Address #217 Copilot review on update_issue: allow milestone:null to cle
**Time:** 2026-07-06T16:44:20.960Z

**Files changed:**
- `src/tools/update_issue.ts`

**Summary:** Address #217 Copilot review on update_issue: allow milestone:null to clear a milestone (schema now nullable), render a cleared milestone as (cleared), and correct the description to say it authenticates with GITHUB_TOKEN or the gh CLI fallback rather than over-promising. Declined the suggested GITHUB_TOKEN-required guard as inconsistent with okffs's global auth model.
```


Closes #218