### PR TITLE
Close #224 - merge_pull_request: accept pr_number for issue-less fix PRs into the base branch (merge-only mode)

### DIFF
--- a/.changes/unreleased/224-merge-pull-request-accept-pr-number.md
+++ b/.changes/unreleased/224-merge-pull-request-accept-pr-number.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- merge_pull_request: accept pr_number for issue-less fix PRs into the base branch (merge-only mode) ([#224](https://github.com/neturely/okffs/issues/224))

--- a/src/tools/merge_pull_request.ts
+++ b/src/tools/merge_pull_request.ts
@@ -19,14 +19,30 @@ import { config } from "../config.js";
 export const name = "merge_pull_request";
 
 export const description =
-  "Autonomously merge a GREEN, review-resolved issue PR into the BASE branch (e.g. develop) using the configured per-tier merge method (OKFFS_BASE_MERGE_METHOD, default squash). " +
+  "Autonomously merge a GREEN, review-resolved PR into the BASE branch (e.g. develop) using the configured per-tier merge method (OKFFS_BASE_MERGE_METHOD, default squash). " +
+  "Provide EXACTLY ONE of: issue_number (merge the issue's PR and complete the loop — comment on the issue and close it when the base isn't the repo default) OR pr_number (merge-only mode for an ISSUE-LESS fix PR into the base branch — skips the issue lookup, comment, and close, and needs no **Branch:** line). " +
   "This is the ONE okffs action that merges — every other tool only opens PRs and hands back. It is therefore heavily gated and OPT-IN: it does nothing unless OKFFS_AUTO_MERGE_BASE=true. " +
   "It NEVER merges OKFFS_PROTECTED_BRANCH (e.g. main) — that stays a manual, user-driven merge/tag — and refuses entirely if OKFFS_PROTECTED_BRANCH is unset, so it can't merge into an unnamed protected branch. " +
   "Before merging it independently verifies (not merely trusting branch-protection rules): the PR targets the base tier and not the protected branch; it is open, not a draft, and free of conflicts; all commit statuses AND check runs on the head are green (no failing or pending checks); the PR is not blocked by a required gate; and every review thread is resolved. Any unmet gate → it refuses with an actionable reason and does not merge. " +
-  "On success it merges, comments on the issue, and — when the base isn't the repo default (so GitHub's Closes #N won't auto-close) — closes the issue to complete the loop. Use for landing small review-fix / feature PRs into develop without a human merge; the develop→main promotion always stays with the user.";
+  "On success (issue mode) it merges, comments on the issue, and — when the base isn't the repo default (so GitHub's Closes #N won't auto-close) — closes the issue to complete the loop. Use for landing small review-fix / feature PRs into develop without a human merge; the develop→main promotion always stays with the user.";
 
 export const inputSchema = z.object({
-  issue_number: z.number().int().positive().describe("The issue whose PR (into the base branch) should be merged"),
+  issue_number: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "The issue whose PR (into the base branch) should be merged — completes the loop (issue comment + close). Provide this OR pr_number, not both."
+    ),
+  pr_number: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "Merge-only mode: merge an ISSUE-LESS fix PR into the base branch directly by PR number — no issue comment/close and no **Branch:** line required, but all the same green gates apply. Provide this OR issue_number, not both."
+    ),
 });
 
 const text = (t: string) => ({ content: [{ type: "text" as const, text: t }] });
@@ -44,6 +60,17 @@ async function getPullRequestWhenComputed(prNumber: number): Promise<PullRequest
 }
 
 export async function handler(input: z.infer<typeof inputSchema>) {
+  // ── Gate 0: exactly one of issue_number / pr_number ───────────────────────
+  const hasIssue = input.issue_number !== undefined;
+  const hasPr = input.pr_number !== undefined;
+  if (hasIssue === hasPr) {
+    return text(
+      "[okffs] Provide exactly one of issue_number (merge an issue's PR and complete the loop — comment + close) " +
+        "or pr_number (merge-only mode for an issue-less fix PR into the base branch). " +
+        (hasIssue ? "You passed both." : "You passed neither.")
+    );
+  }
+
   // ── Gate 1: opt-in ────────────────────────────────────────────────────────
   if (!config.autoMergeBase) {
     return text(
@@ -60,12 +87,6 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     );
   }
 
-  const issue = await getIssue(input.issue_number);
-  const branch = extractBranchFromBody(issue.body);
-  if (!branch) {
-    return text(`Issue #${input.issue_number} has no associated branch (no **Branch:** line), so there's no PR to merge.`);
-  }
-
   const baseTier = await getDefaultBranch(); // OKFFS_BASE_BRANCH or the repo default
 
   // Misconfiguration guard: the base tier must not itself be the protected branch.
@@ -76,13 +97,26 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     );
   }
 
-  const prRef = await getOpenPullRequestForBranch(branch, baseTier);
-  if (!prRef) {
-    return text(`No open PR found for branch \`${branch}\` into \`${baseTier}\`. Open one with create_pull_request first.`);
+  // Resolve the PR to merge. Issue mode reads the issue's **Branch:** line and
+  // finds its open PR into the base tier; merge-only mode takes the PR directly.
+  let prNumber: number;
+  if (hasIssue) {
+    const issue = await getIssue(input.issue_number!);
+    const branch = extractBranchFromBody(issue.body);
+    if (!branch) {
+      return text(`Issue #${input.issue_number} has no associated branch (no **Branch:** line), so there's no PR to merge.`);
+    }
+    const prRef = await getOpenPullRequestForBranch(branch, baseTier);
+    if (!prRef) {
+      return text(`No open PR found for branch \`${branch}\` into \`${baseTier}\`. Open one with create_pull_request first.`);
+    }
+    prNumber = prRef.number;
+  } else {
+    prNumber = input.pr_number!;
   }
 
-  const pr = await getPullRequestWhenComputed(prRef.number);
-  const label = `PR #${pr.number} (${branch} → ${pr.base.ref})`;
+  const pr = await getPullRequestWhenComputed(prNumber);
+  const label = `PR #${pr.number} (${pr.head.ref} → ${pr.base.ref})`;
 
   // ── Gate 3: target is the base tier, never the protected branch ───────────
   if (pr.base.ref === config.protectedBranch) {
@@ -164,24 +198,31 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   const lines = [`✅ Merged ${label} into \`${baseTier}\` via ${method}.`];
 
+  // Merge-only mode: there's no issue to comment on or close — we're done.
+  if (!hasIssue) {
+    return text(lines.join("\n"));
+  }
+
+  const issueNumber = input.issue_number!;
+
   // Complete the loop: `Closes #N` only auto-closes when merging into the repo
   // default. For a non-default base tier (e.g. develop) the issue stays open, so
   // close it here. Non-fatal — the merge already succeeded.
   const repoDefault = await getRepoDefaultBranch();
   if (baseTier !== repoDefault) {
     try {
-      await closeIssue(input.issue_number);
-      lines.push(`Closed #${input.issue_number} (merging into \`${baseTier}\` doesn't trigger GitHub's auto-close).`);
+      await closeIssue(issueNumber);
+      lines.push(`Closed #${issueNumber} (merging into \`${baseTier}\` doesn't trigger GitHub's auto-close).`);
     } catch (err) {
-      lines.push(`⚠ Could not auto-close #${input.issue_number} — close it manually. (${err instanceof Error ? err.message : String(err)})`);
+      lines.push(`⚠ Could not auto-close #${issueNumber} — close it manually. (${err instanceof Error ? err.message : String(err)})`);
     }
   } else {
-    lines.push(`GitHub will auto-close #${input.issue_number} via \`Closes #${input.issue_number}\` (merged into the default branch).`);
+    lines.push(`GitHub will auto-close #${issueNumber} via \`Closes #${issueNumber}\` (merged into the default branch).`);
   }
 
   // Log the merge on the issue for an audit trail.
   try {
-    await addIssueComment(input.issue_number, lines.join("\n"));
+    await addIssueComment(issueNumber, lines.join("\n"));
   } catch {
     /* non-fatal: the response still reports the outcome */
   }


### PR DESCRIPTION
## Summary
merge_pull_request now accepts either issue_number (existing behaviour — merge + issue comment + close) or a new pr_number for a merge-only mode targeting issue-less fix PRs into the base branch. A Gate 0 requires exactly one input: passing neither or both returns an actionable [okffs] message. In pr_number mode the PR is fetched directly by number, the issue lookup / **Branch:** requirement / issue comment / issue close are all skipped, and every existing green gate is applied unchanged — targets the base tier and not OKFFS_PROTECTED_BRANCH; open, non-draft, conflict-free, not blocked/behind; all commit statuses AND check runs green; every review thread resolved — still behind OKFFS_AUTO_MERGE_BASE=true and still refusing when OKFFS_PROTECTED_BRANCH is unset. Uses OKFFS_BASE_MERGE_METHOD. Closes only the merge half of the issue-less fix-into-base gap; the create half is #226.

## Changes
- chore: init branch for #224
- feat: merge_pull_request accepts pr_number for issue-less merge-only mod

## Issue comments

```
### 🔧 Commit update

**Commit:** `71043eb`
**Message:** feat: merge_pull_request accepts pr_number for issue-less merge-only mod
**Time:** 2026-07-08T16:19:05.598Z

**Files changed:**
- `src/tools/merge_pull_request.ts`

**Summary:** feat: merge_pull_request accepts pr_number for issue-less merge-only mode

Accept either issue_number (existing loop: comment + close) or pr_number (new merge-only mode for issue-less fix PRs into the base branch). Exactly one is required — neither/both returns an actionable [okffs] message. pr_number skips the issue lookup, comment, and close and needs no Branch line, but every existing green gate (base-tier target, not protected, open/non-draft/conflict-free, all checks green, not blocked/behind, all threads resolved) plus the OKFFS_AUTO_MERGE_BASE opt-in and OKFFS_PROTECTED_BRANCH requirement are unchanged. Closes #224.
```


Closes #224