### PR TITLE
Close #230 - Harden reply_to_review_comment against reply-without-resolve footgun

### DIFF
--- a/.changes/unreleased/230-harden-reply-to-review-comment-against.md
+++ b/.changes/unreleased/230-harden-reply-to-review-comment-against.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Harden reply_to_review_comment against reply-without-resolve footgun ([#230](https://github.com/neturely/okffs/issues/230))

--- a/src/tools/reply_to_review_comment.ts
+++ b/src/tools/reply_to_review_comment.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
-import { replyToReviewComment } from "../github.js";
+import { replyToReviewComment, getPullRequestReview, resolveReviewThread } from "../github.js";
+import { config } from "../config.js";
 
 export const name = "reply_to_review_comment";
 
 export const description =
-  "Reply to an inline PR review comment thread. Pass the pull request number, the comment id (from list_pr_review_comments), and the reply body. Use after addressing a review comment to record what was changed (e.g. reference the fix commit).";
+  "Reply to an inline PR review comment thread. Pass the pull request number, the comment id (from list_pr_review_comments), and the reply body. Use after addressing a review comment to record what was changed (e.g. reference the fix commit). " +
+  "IMPORTANT: a reply does NOT resolve the thread — the thread stays open until you resolve it. The full loop is list_pr_review_comments → reply_to_review_comment → resolve_review_thread; even when OKFFS_RESOLVE_THREADS=true, resolving is a separate, explicit act (this tool leaves the thread open unless you ask it to resolve). To reply and resolve an addressed thread in one call, pass resolve: true (still gated by OKFFS_RESOLVE_THREADS). Prefer this tool over raw `gh api .../replies`, which skips the resolve path and silently leaves threads unresolved despite OKFFS_RESOLVE_THREADS=true.";
 
 export const inputSchema = z.object({
   pr_number: z.number().int().positive().describe("The pull request number"),
@@ -14,16 +16,47 @@ export const inputSchema = z.object({
     .positive()
     .describe("The review comment id to reply to (from list_pr_review_comments)"),
   body: z.string().describe("Reply body"),
+  resolve: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, also resolve this comment's thread after replying (reply + resolve in one call). Honours the OKFFS_RESOLVE_THREADS gate: when that env var isn't 'true', the reply is still posted but the thread is left open and the response says so. Use ONLY when the reply signals the thread is addressed — not when the reply asks a question or pushes back, which should stay open."
+    ),
 });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
   const reply = await replyToReviewComment(input.pr_number, input.comment_id, input.body);
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: `Replied to comment #${input.comment_id} on PR #${input.pr_number}: ${reply.html_url}`,
-      },
-    ],
-  };
+  const lines = [
+    `Replied to comment #${input.comment_id} on PR #${input.pr_number}: ${reply.html_url}`,
+  ];
+
+  if (input.resolve) {
+    if (!config.resolveThreads) {
+      lines.push(
+        "Not resolving the thread — OKFFS_RESOLVE_THREADS is not enabled, so the reply is posted but the thread is left open for you to resolve on GitHub. Set OKFFS_RESOLVE_THREADS=true to allow reply+resolve in one call."
+      );
+    } else {
+      try {
+        // The reply endpoint works off a comment id; resolving needs the thread
+        // node id, so map comment → thread via the PR's review threads.
+        const { threads } = await getPullRequestReview(input.pr_number);
+        const thread = threads.find((t) => t.comments.some((c) => c.id === input.comment_id));
+        if (!thread) {
+          lines.push(
+            `Could not find the thread for comment #${input.comment_id} to resolve — the reply was posted; resolve it manually if needed.`
+          );
+        } else if (thread.isResolved) {
+          lines.push(`Thread ${thread.id} was already resolved.`);
+        } else {
+          await resolveReviewThread(thread.id);
+          lines.push(`Resolved thread ${thread.id}.`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        lines.push(`Reply posted, but resolving the thread failed: ${msg}`);
+      }
+    }
+  }
+
+  return { content: [{ type: "text" as const, text: lines.join("\n") }] };
 }


### PR DESCRIPTION
## Summary
Two-part hardening of reply_to_review_comment against the reply-without-resolve footgun: (1) the tool description now spells out that a reply does NOT resolve the thread, points at resolve_review_thread as the explicit next step (a separate act even when OKFFS_RESOLVE_THREADS=true), and warns against raw `gh api .../replies` which skips the resolve path entirely; (2) a new optional resolve:true param maps the comment to its review thread (via getPullRequestReview) and resolves it in the same call, still honouring the OKFFS_RESOLVE_THREADS gate — when the gate is off the reply is posted and the thread left open with an explanatory note. Does NOT auto-resolve on every reply (replies used to question/disagree must stay open).

## Changes
- chore: init branch for #230
- feat: harden reply_to_review_comment against reply-without-resolve

## Issue comments

```
### 🔧 Commit update

**Commit:** `f5b2d82`
**Message:** feat: harden reply_to_review_comment against reply-without-resolve

Stre
**Time:** 2026-07-08T16:16:49.428Z

**Files changed:**
- `src/tools/reply_to_review_comment.ts`

**Summary:** feat: harden reply_to_review_comment against reply-without-resolve

Strengthen the tool description to point at resolve_review_thread as the next step, state that a reply alone leaves the thread open (even under OKFFS_RESOLVE_THREADS), and steer away from raw gh api replies. Add an optional resolve:true param that maps the comment to its thread and resolves it in the same call, still gated by OKFFS_RESOLVE_THREADS. Closes #230.
```


Closes #230