### PR TITLE
Release 0.8.0

### DIFF
--- a/.changes/unreleased/224-merge-pull-request-accept-pr-number.md
+++ b/.changes/unreleased/224-merge-pull-request-accept-pr-number.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Fixed -->
-- merge_pull_request: accept pr_number for issue-less fix PRs into the base branch (merge-only mode) ([#224](https://github.com/neturely/okffs/issues/224))

--- a/.changes/unreleased/226-add-an-issue-less-fix-pr.md
+++ b/.changes/unreleased/226-add-an-issue-less-fix-pr.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Fixed -->
-- Add an issue-less "fix PR into base branch" tool (open + merge into develop, the mirror of promote_branch) ([#226](https://github.com/neturely/okffs/issues/226))

--- a/.changes/unreleased/228-commit-and-update-split-hint-into.md
+++ b/.changes/unreleased/228-commit-and-update-split-hint-into.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- commit_and_update: split hint into subject + body instead of a blind 72-char slice ([#228](https://github.com/neturely/okffs/issues/228))

--- a/.changes/unreleased/230-harden-reply-to-review-comment-against.md
+++ b/.changes/unreleased/230-harden-reply-to-review-comment-against.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- Harden reply_to_review_comment against reply-without-resolve footgun ([#230](https://github.com/neturely/okffs/issues/230))

--- a/.changes/unreleased/232-document-fix-into-base-merge-pull.md
+++ b/.changes/unreleased/232-document-fix-into-base-merge-pull.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Fixed -->
-- Document fix_into_base + merge_pull_request pr_number mode; remove leaked INSTRUCTIONS.md and gitignore it ([#232](https://github.com/neturely/okffs/issues/232))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ## [0.8.0] - 2026-07-08
-### Fixed
-- Document fix_into_base + merge_pull_request pr_number mode; remove leaked INSTRUCTIONS.md and gitignore it ([#232](https://github.com/neturely/okffs/issues/232))
+### Added
 - Add an issue-less "fix PR into base branch" tool (open + merge into develop, the mirror of promote_branch) ([#226](https://github.com/neturely/okffs/issues/226))
 - merge_pull_request: accept pr_number for issue-less fix PRs into the base branch (merge-only mode) ([#224](https://github.com/neturely/okffs/issues/224))
 ### Changed
 - Harden reply_to_review_comment against reply-without-resolve footgun ([#230](https://github.com/neturely/okffs/issues/230))
 - commit_and_update: split hint into subject + body instead of a blind 72-char slice ([#228](https://github.com/neturely/okffs/issues/228))
+- Document fix_into_base + merge_pull_request pr_number mode; remove leaked INSTRUCTIONS.md and gitignore it ([#232](https://github.com/neturely/okffs/issues/232))
 
 ## [0.7.0] - 2026-07-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-08
+### Fixed
+- Document fix_into_base + merge_pull_request pr_number mode; remove leaked INSTRUCTIONS.md and gitignore it ([#232](https://github.com/neturely/okffs/issues/232))
+- Add an issue-less "fix PR into base branch" tool (open + merge into develop, the mirror of promote_branch) ([#226](https://github.com/neturely/okffs/issues/226))
+- merge_pull_request: accept pr_number for issue-less fix PRs into the base branch (merge-only mode) ([#224](https://github.com/neturely/okffs/issues/224))
+### Changed
+- Harden reply_to_review_comment against reply-without-resolve footgun ([#230](https://github.com/neturely/okffs/issues/230))
+- commit_and_update: split hint into subject + body instead of a blind 72-char slice ([#228](https://github.com/neturely/okffs/issues/228))
+
 ## [0.7.0] - 2026-07-06
 ### Added
 - Address #217 review: allow clearing milestone in update_issue + accurate auth wording ([#218](https://github.com/neturely/okffs/issues/218))
@@ -135,7 +144,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/neturely/okffs/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/neturely/okffs/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/neturely/okffs/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/neturely/okffs/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/neturely/okffs/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/neturely/okffs/compare/v0.5.1...v0.5.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neturely/okffs",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "mcpName": "io.github.neturely/okffs",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",


### PR DESCRIPTION
## Release 0.8.0

- Bumped `package.json` and `package-lock.json` to 0.8.0.
- Rolled the CHANGELOG `[Unreleased]` section into `## [0.8.0]` and refreshed the compare links.
- Assembled and removed 5 changelog fragment(s) from `.changes/unreleased/`.

After merging, tag `v0.8.0` and push it — CI (`publish.yml`) publishes to npm on the tag. This PR does not tag or publish.