### PR TITLE
Close #236 - commit_and_update: empty commit subject from whitespace-only or leading-blank-line hint

### DIFF
--- a/.changes/unreleased/236-commit-and-update-empty-commit-subject.md
+++ b/.changes/unreleased/236-commit-and-update-empty-commit-subject.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- commit_and_update: empty commit subject from whitespace-only or leading-blank-line hint ([#236](https://github.com/neturely/okffs/issues/236))

--- a/src/tools/commit_and_update.ts
+++ b/src/tools/commit_and_update.ts
@@ -16,18 +16,26 @@ const SUBJECT_MAX = 72;
 /**
  * Split a free-text hint into a git commit subject + optional body.
  *
- * - Subject: the first line, truncated to ~72 chars at a **word boundary**
- *   (never mid-word) — a single unbreakable word longer than the limit is the
- *   only case that gets a hard cut.
- * - Body: any remaining lines, plus whatever overflowed past the subject on the
- *   first line, joined as blank-line-separated paragraphs. `undefined` when the
+ * - Subject: the first **non-blank** line, truncated to ~72 chars at a **word
+ *   boundary** (never mid-word) — a single unbreakable word longer than the
+ *   limit is the only case that gets a hard cut. Leading blank lines are skipped
+ *   so a hint like "\nAdd X" doesn't produce an empty subject (#236).
+ * - Body: any lines after the subject line, plus whatever overflowed past the
+ *   subject, joined as blank-line-separated paragraphs. `undefined` when the
  *   hint fits entirely in the subject, so a short single-line hint behaves
  *   exactly as before (subject only). (#228)
+ *
+ * A whitespace-only hint has no usable subject line and returns `{ subject: "" }`
+ * — the handler guards against that by treating a blank hint as absent (#236).
  */
 export function splitCommitMessage(hint: string): { subject: string; body?: string } {
   const lines = hint.split("\n");
-  const firstLine = lines[0].trim();
-  const rest = lines.slice(1).join("\n").trim();
+  // Take the subject from the first non-blank line, not lines[0], so leading
+  // blank lines don't yield an empty subject.
+  const firstIdx = lines.findIndex((l) => l.trim() !== "");
+  if (firstIdx === -1) return { subject: "" };
+  const firstLine = lines[firstIdx].trim();
+  const rest = lines.slice(firstIdx + 1).join("\n").trim();
 
   let subject = firstLine;
   let overflow = "";
@@ -60,7 +68,9 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     changedFiles = [];
   }
 
-  const hintText = input.hint ?? "";
+  // Trim so a whitespace-only hint (e.g. "   ") counts as absent — otherwise it
+  // is truthy and yields an empty commit subject (#236).
+  const hintText = (input.hint ?? "").trim();
   const filesText = changedFiles.length > 0 ? changedFiles.join(", ") : "various files";
 
   // Build the commit subject (and optional body) from the hint when provided,


### PR DESCRIPTION
## Summary
Fixes the two edge cases Copilot flagged on the #235 promotion PR, both in the #228 splitCommitMessage work. (1) splitCommitMessage now derives the subject from the first non-blank line (skipping leading blank lines) instead of lines[0], so a hint like "\nAdd X" no longer yields an empty subject. (2) The handler trims the hint before its presence check, so a whitespace-only hint ("   ") counts as absent and falls back to the "chore: update <files>" message instead of producing git commit -m "". Short and long single-line hints are byte-for-byte unchanged; verified against whitespace-only, leading-blank, multi-blank+body, short, and long inputs. Folds into 0.8.0 (hardens the #228 feature shipping in the same release).

## Changes
- chore: init branch for #236
- fix: guard commit_and_update against empty subject from blank hints

## Issue comments

```
### 🔧 Commit update

**Commit:** `7dc0493`
**Message:** fix: guard commit_and_update against empty subject from blank hints

spl
**Time:** 2026-07-08T16:58:14.573Z

**Files changed:**
- `src/tools/commit_and_update.ts`

**Summary:** fix: guard commit_and_update against empty subject from blank hints

splitCommitMessage now takes the subject from the first non-blank line (skipping leading blank lines) and the handler trims the hint so a whitespace-only hint counts as absent and falls back to the file-list message. Fixes the two Copilot edge cases (whitespace-only hint; hint starting with a blank line) that produced git commit -m "". Short/long single-line hints unchanged. Closes #236.
```


Closes #236