### PR TITLE
Close #247 - Silent auto-PR failure in create_issue - swallowed to stderr, retry on 422

### DIFF
--- a/.changes/unreleased/247-silent-auto-pr-failure-in-create.md
+++ b/.changes/unreleased/247-silent-auto-pr-failure-in-create.md
@@ -1,2 +1,2 @@
-<!-- okffs:type=Added -->
+<!-- okffs:type=Fixed -->
 - Silent auto-PR failure in create_issue - swallowed to stderr, retry on 422 ([#247](https://github.com/neturely/okffs/issues/247))

--- a/.changes/unreleased/247-silent-auto-pr-failure-in-create.md
+++ b/.changes/unreleased/247-silent-auto-pr-failure-in-create.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- Silent auto-PR failure in create_issue - swallowed to stderr, retry on 422 ([#247](https://github.com/neturely/okffs/issues/247))

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ dist/
 # Environment files
 .env
 .env.*.local
+# Backups may be copies of .env (with a live token) — never commit them
+*.bak
 
 # Personal/local notes (not for the public repo)
 instructions

--- a/src/github.ts
+++ b/src/github.ts
@@ -317,16 +317,42 @@ export async function getIssueComments(issueNumber: number): Promise<Array<{ bod
   return request(`/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100&sort=created&direction=desc`);
 }
 
+// GitHub can reject a PR POST with 422 "No commits between <base> and <head>"
+// when the POST outruns GitHub's own indexing of a commit that was pushed moments
+// earlier — the push→open-PR eventual-consistency race behind #247. It resolves
+// within seconds, so retry PR creation a few times with a short backoff. Any other
+// error (real "no commits", bad base, permissions, …) is rethrown immediately.
+// Centralised here so every PR-open path benefits: create_issue's auto-PR, the
+// allow_empty backfill (create_pull_request / commit_and_update), promote_branch,
+// and fix_into_base — all go through createPullRequest / createDraftPullRequest.
+async function withPrCreateRetry<T>(fn: () => Promise<T>, attempts = 4, delayMs = 1500): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isIndexingRace = /error 422/.test(msg) && /no commits between/i.test(msg);
+      if (!isIndexingRace || attempt >= attempts) throw err;
+      console.warn(
+        `[okffs] PR creation hit the push→POST indexing race (422 no commits) — retry ${attempt}/${attempts - 1} in ${delayMs}ms.`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
 export async function createPullRequest(
   title: string,
   body: string,
   head: string,
   base: string
 ): Promise<{ number: number; html_url: string; node_id: string }> {
-  return request(`/repos/${owner}/${repo}/pulls`, {
-    method: "POST",
-    body: JSON.stringify({ title, head, base, body }),
-  });
+  return withPrCreateRetry(() =>
+    request(`/repos/${owner}/${repo}/pulls`, {
+      method: "POST",
+      body: JSON.stringify({ title, head, base, body }),
+    })
+  );
 }
 
 // Request reviewers on a PR (REST). Used by promote_branch to put the configured
@@ -437,10 +463,12 @@ export async function createDraftPullRequest(
   head: string,
   base: string
 ): Promise<{ number: number; html_url: string }> {
-  return request(`/repos/${owner}/${repo}/pulls`, {
-    method: "POST",
-    body: JSON.stringify({ title, head, base, body, draft: true }),
-  });
+  return withPrCreateRetry(() =>
+    request(`/repos/${owner}/${repo}/pulls`, {
+      method: "POST",
+      body: JSON.stringify({ title, head, base, body, draft: true }),
+    })
+  );
 }
 
 export function extractBranchFromBody(body: string | null): string | null {

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -137,6 +137,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   }
 
   let draftPRUrl: string | null = null;
+  let autoPRError: string | null = null;
   if (config.autoPR) {
     // Push an empty init commit so the branch diverges from base, allowing
     // GitHub to accept a draft PR immediately. Only needed for the auto-PR flow.
@@ -156,7 +157,12 @@ export async function handler(input: z.infer<typeof inputSchema>) {
       );
       draftPRUrl = pr.html_url;
     } catch (err) {
-      console.warn("[okffs] Failed to create draft PR:", err instanceof Error ? err.message : err);
+      // Non-fatal, but surface it as data in the response — never only to stderr,
+      // which the host/user never sees. This is the #146 board convention applied
+      // to the auto-PR block: otherwise create_issue looks like it silently
+      // half-succeeded, with the missing `Draft PR:` line the only clue (#247).
+      autoPRError = err instanceof Error ? err.message : String(err);
+      console.warn("[okffs] Failed to create draft PR:", autoPRError);
     }
   }
 
@@ -178,6 +184,11 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   if (draftPRUrl) {
     lines.push(`Draft PR: ${draftPRUrl}`);
+  } else if (autoPRError) {
+    lines.push(
+      `⚠ Auto-PR failed — ${autoPRError}`,
+      `  (Non-fatal: the issue + branch are created. create_pull_request backfills the draft PR when you open the real PR.)`
+    );
   }
 
   if (resolvedAssignees.length > 0) {


### PR DESCRIPTION
## Summary
Two complementary fixes for the silent auto-PR failure:

1. Surface auto-PR failure as data — create_issue now emits a `⚠ Auto-PR failed — <reason>` line (with a note that it's non-fatal and self-heals via create_pull_request) instead of only console.warn'ing to stderr. Applies the #146 board convention to the auto-PR block so create_issue never looks like it silently half-succeeded.

2. Centralized 422 retry — createPullRequest and createDraftPullRequest now retry with backoff on the 422 "No commits between base and head" push->POST eventual-consistency race (the actual trigger). Centralized in github.ts so every PR-open path benefits: create_issue auto-PR, allow_empty backfill, promote_branch, fix_into_base.

Also gitignored *.bak so .env backups (which may contain a live token) can never be committed.

## Changes
- chore: init branch for #247
- Fix silent auto-PR failure in create_issue

## Issue comments

```
### 🔧 Commit update

**Commit:** `cd52ce2`
**Message:** Fix silent auto-PR failure in create_issue
**Time:** 2026-07-14T10:41:53.865Z

**Files changed:**
- `.gitignore`
- `src/github.ts`
- `src/tools/create_issue.ts`

**Summary:** Fix silent auto-PR failure in create_issue

Surface auto-PR failures as a WARN line in the create_issue response (per the #146 board convention) instead of swallowing them to stderr, so create_issue never looks like it silently half-succeeded. Also centralize a retry/backoff around PR creation (createPullRequest/createDraftPullRequest) that defends against the push->POST 422 "No commits between" eventual-consistency race, benefiting every PR-open path. Also gitignore *.bak so .env backups can never be committed.
```


---


```
### Second sighting: bulk creation, 1 of 18 auto-PRs silently failed

Reproduced again during bulk issue creation in a consumer repo (`plan` under `OKFFS_AUTO_PR=true`) - 1 of 18 branches got no draft PR, no signal in the tool response, needing a manual patch. Same 422 eventual-consistency race, same silent swallow.

**The fix must cover the bulk path too, not just `create_issue`.** `src/tools/plan.ts:231-246` has the identical swallow: `createDraftPullRequest` in try/catch, failure only `console.warn`'d, missing PRs simply absent from `draftPRs` and the response.

If anything the bulk path is *more* race-exposed: `plan.ts` pushes every init commit in one loop (L206-217), then opens every draft PR in a second loop (L231-246) - a batch of back-to-back `POST /pulls`, each still vulnerable to "No commits between base and branch" if GitHub hasn't indexed that branch's commit yet. At 18 issues, ~1 hitting the race is exactly the observed rate.

**Scope for the fix:**
- Both `create_issue.ts:150-160` and `plan.ts:231-246` (and any shared helper `create_issues_from_list` grows if auto-PR is added there).
- Best handled by centralizing the retry: wrap `createDraftPullRequest` in a small retry-on-422/backoff helper and call it from both paths, plus surface any final failure as a response line (per the #146 convention) so a missing PR in a batch of 18 is visible, not silent.
```


Closes #247