### PR TITLE
Fix into develop: fix-copilot-review-250

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -27,7 +27,11 @@ export function autopilotEnabled(): boolean {
  * emitting an empty heading. Blank/whitespace-only entries are dropped. #238.
  */
 export function renderAutopilotDecisions(decisions?: string[] | null): string | null {
-  const items = (decisions ?? []).map((d) => d.trim()).filter(Boolean);
+  // Strip a leading bullet marker (-, *, •) the caller may have already added, so
+  // "- chose X" and "chose X" both render as a single bullet rather than "- - …".
+  const items = (decisions ?? [])
+    .map((d) => d.trim().replace(/^[-*•]\s+/, "").trim())
+    .filter(Boolean);
   if (items.length === 0) return null;
   return ["## 🤖 Autopilot decisions", ...items.map((d) => `- ${d}`)].join("\n");
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -325,6 +325,27 @@ export async function getIssueComments(issueNumber: number): Promise<Array<{ bod
 // Centralised here so every PR-open path benefits: create_issue's auto-PR, the
 // allow_empty backfill (create_pull_request / commit_and_update), promote_branch,
 // and fix_into_base — all go through createPullRequest / createDraftPullRequest.
+// Turn a thrown request() error ("GitHub API error 422: {json body}") into a
+// concise, human message — "<status> <github message>" — by extracting GitHub's
+// `message` field from the JSON body instead of dumping the whole raw response.
+// Keeps tool-facing text (e.g. create_issue's auto-PR WARN line) readable (#247
+// review). Falls back to the raw string when it doesn't match the known shape.
+export function summarizeGitHubError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const m = raw.match(/^GitHub (?:API|GraphQL) error (\d+): ([\s\S]*)$/);
+  if (!m) return raw;
+  const [, status, body] = m;
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed.message === "string" && parsed.message.trim()) {
+      return `${status} ${parsed.message.trim()}`;
+    }
+  } catch {
+    /* body isn't JSON — fall through to the trimmed raw form */
+  }
+  return `${status} ${body}`.trim();
+}
+
 async function withPrCreateRetry<T>(fn: () => Promise<T>, attempts = 4, delayMs = 1500): Promise<T> {
   for (let attempt = 1; ; attempt++) {
     try {

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, buildBranchName, createDraftPullRequest } from "../github.js";
+import { createIssue, updateIssueBody, getDefaultBranch, getRef, createBranch, buildBranchName, createDraftPullRequest, summarizeGitHubError } from "../github.js";
 import { config } from "../config.js";
 import { pushEmptyInitCommit } from "../git.js";
 import {
@@ -162,7 +162,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
       // which the host/user never sees. This is the #146 board convention applied
       // to the auto-PR block: otherwise create_issue looks like it silently
       // half-succeeded, with the missing `Draft PR:` line the only clue (#247).
-      autoPRError = err instanceof Error ? err.message : String(err);
+      autoPRError = summarizeGitHubError(err);
       console.warn("[okffs] Failed to create draft PR:", autoPRError);
     }
   }

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -7,6 +7,7 @@ import {
   createBranch,
   buildBranchName,
   createDraftPullRequest,
+  summarizeGitHubError,
 } from "../github.js";
 import { config } from "../config.js";
 import { git, currentBranch } from "../git.js";
@@ -199,6 +200,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   // Optionally open a draft PR per branch. Mirrors create_issue: push an empty
   // init commit so the branch diverges from base, then open the draft PR.
   const draftPRs: Record<number, string> = {};
+  const draftPRErrors: Record<number, string> = {};
   if (config.autoPR) {
     const previousBranch = currentBranch();
     try {
@@ -238,9 +240,14 @@ export async function handler(input: z.infer<typeof inputSchema>) {
         );
         draftPRs[entry.number] = pr.html_url;
       } catch (err) {
+        // Surface the per-issue failure as data in the response — never only to
+        // stderr — so a bulk run can't look like a silent partial success when a
+        // draft PR wasn't created (the #146 convention, applied to the bulk path
+        // like create_issue's single path — #247 review).
+        draftPRErrors[entry.number] = summarizeGitHubError(err);
         console.warn(
           `[okffs] Failed to create draft PR for #${entry.number}:`,
-          err instanceof Error ? err.message : err
+          draftPRErrors[entry.number]
         );
       }
     }
@@ -262,6 +269,11 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     ];
     if (draftPRs[entry.number]) {
       lines.push(`  Draft PR: ${draftPRs[entry.number]}`);
+    } else if (draftPRErrors[entry.number]) {
+      lines.push(
+        `  ⚠ Auto-PR failed — ${draftPRErrors[entry.number]}`,
+        `    (Non-fatal: the issue + branch exist. create_pull_request backfills the draft PR later.)`
+      );
     }
     lines.push(
       ...renderBoardLines({


### PR DESCRIPTION
Address Copilot's review on the 0.10.0 promotion PR (#250):

- create_issue / github.ts: summarizeGitHubError() extracts GitHub's `message` field + status code from thrown request errors, so the auto-PR WARN line is a concise "422 No commits between…" instead of the full raw JSON body.
- plan: the bulk auto-PR path now records per-issue draft-PR failures and surfaces them as a WARN line in the tool response (not only console.warn) — extending the #146/#247 "never a silent partial success" convention to bulk runs.
- autopilot: renderAutopilotDecisions() strips a leading bullet marker so a caller passing "- foo" doesn't produce "- - foo".

Lands on develop so it folds into the 0.10.0 promotion.

## Landing (1 commit)
- Address Copilot review on #250: cleaner auto-PR errors, bulk WARN, bullet-safe decisions