### PR TITLE
Close #253 - Harden env-var parsing: filter empty entries in comma-list vars + audit empty/missing values

### DIFF
--- a/.changes/unreleased/253-harden-env-var-parsing-filter-empty.md
+++ b/.changes/unreleased/253-harden-env-var-parsing-filter-empty.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Harden env-var parsing: filter empty entries in comma-list vars + audit empty/missing values ([#253](https://github.com/neturely/okffs/issues/253))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,12 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 - New tools won't appear in consumer repos until a new version is published to npm.
 - After any build change in the okffs repo, restart Claude Code or run `/mcp` to pick up the updated `dist/index.js`.
 
+## Testing
+
+- `npm test` runs the [`node:test`](https://nodejs.org/api/test.html) suite via the existing `tsx` loader (`node --import tsx --test "src/**/*.test.ts"`) — zero extra dependencies. Tests live beside the code they cover as `*.test.ts` and are excluded from the `tsc` build (`tsconfig.json`), so they never emit into `dist/` or ship to npm.
+- Coverage is currently a minimal baseline (started in #253: `parseCommaList` in `src/config.test.ts`). Prefer testing **pure-logic** functions (data transforms, parsing, inference, invariant checks) over the GitHub API-calling layer. Broader coverage is tracked as a follow-up.
+- CI does **not** yet gate on `npm test` — running it is a manual/local step for now.
+
 ## Codebase search
 
 This project uses [semble](https://github.com/MinishLab/semble) for semantic code search. The MCP server is registered at the user level (`~/.claude.json`) and a dedicated sub-agent is configured at `.claude/agents/semble-search.md`.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepublishOnly": "npm run build",
     "postbuild": "node -e \"const fs=require('fs');for(const f of ['dist/index.js','dist/cli/index.js']){const c=fs.readFileSync(f,'utf8');if(!c.startsWith('#!/usr/bin/env node'))fs.writeFileSync(f,'#!/usr/bin/env node\\n'+c);}\" && chmod +x dist/index.js dist/cli/index.js",
     "dev": "node --env-file=.env --import tsx/esm src/index.ts",
-    "start": "node --env-file=.env dist/index.js"
+    "start": "node --env-file=.env dist/index.js",
+    "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "keywords": [
     "mcp",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseCommaList } from "./config.js";
+
+// Regression coverage for #253: comma-list env vars must drop empty entries so a
+// malformed-but-truthy value (trailing comma, whitespace) never emits a phantom
+// "" that reaches the GitHub API as an invalid label/assignee.
+test("parseCommaList drops empty entries", () => {
+  // Unset / empty → [] (the supported "none" case).
+  assert.deepEqual(parseCommaList(undefined), []);
+  assert.deepEqual(parseCommaList(""), []);
+
+  // Whitespace-only → [] (was ["\"\""] before the fix).
+  assert.deepEqual(parseCommaList(" "), []);
+  assert.deepEqual(parseCommaList(" , "), []);
+
+  // Trailing comma → no phantom trailing entry.
+  assert.deepEqual(parseCommaList("okffs,"), ["okffs"]);
+
+  // Interior empty entry → dropped, order preserved.
+  assert.deepEqual(parseCommaList("a, ,b,"), ["a", "b"]);
+
+  // Well-formed input is trimmed and preserved.
+  assert.deepEqual(parseCommaList("x, y"), ["x", "y"]);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,15 @@
+// Parse a comma-separated env var into a trimmed list with empty entries
+// dropped. An unset or empty value yields []; trailing commas and whitespace-only
+// entries (e.g. "okffs," → ["okffs"], " " → []) never emit a phantom "" that would
+// otherwise reach the GitHub API as an invalid label/assignee. Pure over its input
+// so the parsing is unit-testable without mutating process.env (#253).
+export function parseCommaList(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 // GitHub's three PR merge methods. okffs records the method per branch tier
 // (base vs protected) so a merge — whoever performs it — uses the convention the
 // repo settled on (e.g. squash into develop, merge-commit into main). #209.
@@ -9,8 +21,10 @@ const MERGE_METHODS: readonly MergeMethod[] = ["squash", "merge", "rebase"];
 // falls back to the default rather than failing startup.
 function parseMergeMethod(envVar: string, def: MergeMethod): MergeMethod {
   const raw = process.env[envVar];
-  if (!raw) return def;
-  const value = raw.trim().toLowerCase();
+  // Trim before the emptiness check so a whitespace-only value takes the default
+  // silently too, rather than warning as if it were a genuine invalid method.
+  const value = raw?.trim().toLowerCase();
+  if (!value) return def;
   if ((MERGE_METHODS as readonly string[]).includes(value)) return value as MergeMethod;
   console.warn(
     `[okffs] ${envVar}="${raw}" is not a valid merge method (expected one of ${MERGE_METHODS.join(", ")}) — falling back to "${def}".`
@@ -18,14 +32,15 @@ function parseMergeMethod(envVar: string, def: MergeMethod): MergeMethod {
   return def;
 }
 
+// Invariant: an empty or unset env value degrades to a safe no-op, never an
+// error (#253). Scalars use `|| null` (empty ⇒ null), booleans use `=== "true"`
+// (empty ⇒ false) or `!== "false"` for default-on (empty ⇒ true), comma-lists go
+// through parseCommaList (empty/whitespace/trailing-comma ⇒ no phantom entry),
+// and parseMergeMethod falls back to its default. No env var throws on empty.
 export const config = {
   promptForMetadata: process.env.OKFFS_PROMPT_METADATA !== "false",
-  defaultAssignees: process.env.OKFFS_DEFAULT_ASSIGNEES
-    ? process.env.OKFFS_DEFAULT_ASSIGNEES.split(",").map((s) => s.trim())
-    : [],
-  defaultLabels: process.env.OKFFS_DEFAULT_LABELS
-    ? process.env.OKFFS_DEFAULT_LABELS.split(",").map((s) => s.trim())
-    : [],
+  defaultAssignees: parseCommaList(process.env.OKFFS_DEFAULT_ASSIGNEES),
+  defaultLabels: parseCommaList(process.env.OKFFS_DEFAULT_LABELS),
   baseBranch: process.env.OKFFS_BASE_BRANCH || null,
   // OKFFS_PROTECTED_BRANCH — a branch okffs won't open/finalize a PR into without
   // explicit user confirmation (e.g. `main`). create_pull_request refuses to
@@ -76,9 +91,7 @@ export const config = {
   // new/changed functionality when a PR is created (intelligent, not a changelog
   // append). Default false. The `update_guidance` prompt works regardless.
   updateGuidance: process.env.OKFFS_UPDATE_GUIDANCE === "true",
-  excludeDocs: process.env.OKFFS_EXCLUDE_DOCS
-    ? process.env.OKFFS_EXCLUDE_DOCS.split(",").map((s) => s.trim())
-    : [],
+  excludeDocs: parseCommaList(process.env.OKFFS_EXCLUDE_DOCS),
   // ── GitHub Projects v2 (Phase 5) ──────────────────────────────────────────
   // OKFFS_PROJECT_ENABLED=true — opt-in; surfaces the project column in
   // list_issues and lets update_project_status run. Zero overhead when unset.
@@ -136,9 +149,7 @@ export const config = {
   // Copilot code review, the develop→main review convention). Unset = request no
   // reviewers. Best-effort: a failure warns and never blocks the PR. (#182)
   // Only acted on when OKFFS_PROMOTION_AUTO_REVIEW is true.
-  promotionReviewers: process.env.OKFFS_PROMOTION_REVIEWERS
-    ? process.env.OKFFS_PROMOTION_REVIEWERS.split(",").map((s) => s.trim()).filter(Boolean)
-    : [],
+  promotionReviewers: parseCommaList(process.env.OKFFS_PROMOTION_REVIEWERS),
   // OKFFS_PROMOTION_AUTO_REVIEW — explicit opt-in for promote_branch to auto-request
   // OKFFS_PROMOTION_REVIEWERS on the gate PR. Default false (cost-safe). When true,
   // reviewers are requested ONLY when the gate PR is first created — never on

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
Hardens comma-separated env-var parsing so malformed-but-truthy values can't inject empty entries into GitHub API calls, and establishes a minimal test baseline.

Fix: a new pure `parseCommaList(raw)` trims and `.filter(Boolean)`s, replacing the four ad-hoc split/trim sites (defaultAssignees, defaultLabels, excludeDocs — which lacked the filter — plus promotionReviewers, which already had it). A trailing comma (`okffs,`) or whitespace-only value (`" "`) previously produced `["okffs",""]` / `[""]`, sent straight to GitHub as an invalid label/assignee. `parseMergeMethod` now trims before its emptiness check so a whitespace-only value falls back silently instead of warning.

Audit: added a comment over the config object making the "empty/unset env value ⇒ safe no-op, never an error" invariant explicit; confirmed all scalar (`|| null`), boolean (`=== "true"` / `!== "false"`), and merge-method vars already satisfy it — the comma-lists were the only gap.

Test baseline: added a minimal node:test harness (`npm test`, run through the already-present tsx, zero new deps) with config.test.ts covering the trailing-comma / whitespace / interior-empty / unset cases. Excluded `*.test.ts` from the tsc build so test files never emit into dist or ship in the npm tarball (verified via publish --dry-run).

Out of scope (noted for a follow-up issue): broader test coverage of other pure-logic functions, and CI wiring to gate publish on `npm test`. The optional non-existent-label validation from the issue is also left as a separate question.

## Changes
- chore: init branch for #253
- fix(config): harden comma-list env parsing + add node:test baseline.

## Issue comments

```
### 🔧 Commit update

**Commit:** `f01024f`
**Message:** fix(config): harden comma-list env parsing + add node:test baseline.
**Time:** 2026-07-16T17:32:46.273Z

**Files changed:**
- `package.json`
- `src/config.ts`
- `tsconfig.json`

**Summary:** fix(config): harden comma-list env parsing + add node:test baseline. Add pure parseCommaList(raw) that trims and drops empty entries, and route defaultAssignees/defaultLabels/excludeDocs/promotionReviewers through it so a trailing comma or whitespace-only value no longer emits a phantom "" that reaches the GitHub API as an invalid label/assignee (#253). Trim before the emptiness check in parseMergeMethod so a whitespace-only value falls back silently. Document the "empty env value ⇒ safe no-op, never an error" invariant as a comment over the config object. Add a minimal node:test harness (npm test, via existing tsx, zero new deps) with config.test.ts covering the trailing-comma/whitespace/interior-empty cases; exclude *.test.ts from the tsc build so tests never emit into dist or ship to npm.

```


Closes #253