### PR TITLE
Release 0.10.1

### DIFF
--- a/.changes/unreleased/253-harden-env-var-parsing-filter-empty.md
+++ b/.changes/unreleased/253-harden-env-var-parsing-filter-empty.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- Harden env-var parsing: filter empty entries in comma-list vars + audit empty/missing values ([#253](https://github.com/neturely/okffs/issues/253))

--- a/.changes/unreleased/255-address-pr-review-route-protected-head.md
+++ b/.changes/unreleased/255-address-pr-review-route-protected-head.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Fixed -->
-- address_pr_review: route protected-head fixes through fix_into_base, not a follow-up issue + issue branch ([#255](https://github.com/neturely/okffs/issues/255))

--- a/.changes/unreleased/257-list-issues-board-column-is-cross.md
+++ b/.changes/unreleased/257-list-issues-board-column-is-cross.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- list_issues board column is cross-repo unsafe — project: reports another repo's status on number collisions ([#257](https://github.com/neturely/okffs/issues/257))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-16
+### Changed
+- list_issues board column is cross-repo unsafe — project: reports another repo's status on number collisions ([#257](https://github.com/neturely/okffs/issues/257))
+- Harden env-var parsing: filter empty entries in comma-list vars + audit empty/missing values ([#253](https://github.com/neturely/okffs/issues/253))
+### Fixed
+- address_pr_review: route protected-head fixes through fix_into_base, not a follow-up issue + issue branch ([#255](https://github.com/neturely/okffs/issues/255))
+
 ## [0.10.0] - 2026-07-14
 ### Added
 - Autopilot / "minimum interference" mode — autonomous issue → develop-PR with a decisions report ([#238](https://github.com/neturely/okffs/issues/238))
@@ -157,7 +164,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/neturely/okffs/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/neturely/okffs/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/neturely/okffs/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/neturely/okffs/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/neturely/okffs/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/neturely/okffs/compare/v0.7.0...v0.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neturely/okffs",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "mcpName": "io.github.neturely/okffs",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",


### PR DESCRIPTION
## Release 0.10.1

- Bumped `package.json` and `package-lock.json` to 0.10.1.
- Rolled the CHANGELOG `[Unreleased]` section into `## [0.10.1]` and refreshed the compare links.
- Assembled and removed 3 changelog fragment(s) from `.changes/unreleased/`.

After merging, tag `v0.10.1` and push it — CI (`publish.yml`) publishes to npm on the tag. This PR does not tag or publish.