### PR TITLE
Harden .gitignore: ignore all env file variants and backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,11 @@ Thumbs.db
 
 # GitHub CLI / tool local state (never commit or publish)
 .local/
+# env files — never commit (any variant or backup)
+.env
+.env.*
+*.env
+*.env.bak
+!.env.example
+!.env.sample
+!.env-example


### PR DESCRIPTION
Security hardening after env backup files were accidentally committed elsewhere (felix incident): ignore .env, .env.*, *.env, *.env.bak, with .env.example/.env.sample/.env-example still allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)