### PR TITLE
Close #271 - summarizeGitHubError drops the 422 errors[] detail; auto-PR retry predicate misses "Validation Failed" 422s

### DIFF
--- a/.changes/unreleased/271-summarizegithuberror-drops-the-422-errors-detail.md
+++ b/.changes/unreleased/271-summarizegithuberror-drops-the-422-errors-detail.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- summarizeGitHubError drops the 422 errors[] detail; auto-PR retry predicate misses "Validation Failed" 422s ([#271](https://github.com/neturely/okffs/issues/271))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ When `OKFFS_IDENTIFIER` is set, a project-scoped prefix is inserted: `{issue-num
 ## Testing
 
 - `npm test` runs the [`node:test`](https://nodejs.org/api/test.html) suite via the existing `tsx` loader (`node --import tsx --test "src/**/*.test.ts"`) — zero extra dependencies. Tests live beside the code they cover as `*.test.ts` and are excluded from the `tsc` build (`tsconfig.json`), so they never emit into `dist/` or ship to npm.
-- Coverage is currently a minimal baseline (started in #253: `parseCommaList` in `src/config.test.ts`). Prefer testing **pure-logic** functions (data transforms, parsing, inference, invariant checks) over the GitHub API-calling layer. Broader coverage is tracked as a follow-up.
+- Coverage is currently a minimal baseline (started in #253: `parseCommaList` in `src/config.test.ts`; #271 added `src/github_errors.test.ts` for the pure error helpers — note `github.ts` itself can't be imported in tests, it resolves token/repo at import time, which is why the pure helpers live in `src/github_errors.ts`). Prefer testing **pure-logic** functions (data transforms, parsing, inference, invariant checks) over the GitHub API-calling layer. Broader coverage is tracked as a follow-up.
 - CI does **not** yet gate on `npm test` — running it is a manual/local step for now.
 
 ## Codebase search

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { config } from "./config.js";
+import { isPrCreateRaceError } from "./github_errors.js";
 
 const BASE = "https://api.github.com";
 
@@ -325,26 +326,10 @@ export async function getIssueComments(issueNumber: number): Promise<Array<{ bod
 // Centralised here so every PR-open path benefits: create_issue's auto-PR, the
 // allow_empty backfill (create_pull_request / commit_and_update), promote_branch,
 // and fix_into_base — all go through createPullRequest / createDraftPullRequest.
-// Turn a thrown request() error ("GitHub API error 422: {json body}") into a
-// concise, human message — "<status> <github message>" — by extracting GitHub's
-// `message` field from the JSON body instead of dumping the whole raw response.
-// Keeps tool-facing text (e.g. create_issue's auto-PR WARN line) readable (#247
-// review). Falls back to the raw string when it doesn't match the known shape.
-export function summarizeGitHubError(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  const m = raw.match(/^GitHub (?:API|GraphQL) error (\d+): ([\s\S]*)$/);
-  if (!m) return raw;
-  const [, status, body] = m;
-  try {
-    const parsed = JSON.parse(body);
-    if (parsed && typeof parsed.message === "string" && parsed.message.trim()) {
-      return `${status} ${parsed.message.trim()}`;
-    }
-  } catch {
-    /* body isn't JSON — fall through to the trimmed raw form */
-  }
-  return `${status} ${body}`.trim();
-}
+// The error-summarising and race-detection helpers live in github_errors.ts
+// (pure, import-safe without a configured env, unit-tested — #271); re-exported
+// here so existing importers keep working.
+export { summarizeGitHubError } from "./github_errors.js";
 
 async function withPrCreateRetry<T>(fn: () => Promise<T>, attempts = 4, delayMs = 1500): Promise<T> {
   for (let attempt = 1; ; attempt++) {
@@ -352,10 +337,9 @@ async function withPrCreateRetry<T>(fn: () => Promise<T>, attempts = 4, delayMs 
       return await fn();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      const isIndexingRace = /error 422/.test(msg) && /no commits between/i.test(msg);
-      if (!isIndexingRace || attempt >= attempts) throw err;
+      if (!isPrCreateRaceError(msg) || attempt >= attempts) throw err;
       console.warn(
-        `[okffs] PR creation hit the push→POST indexing race (422 no commits) — retry ${attempt}/${attempts - 1} in ${delayMs}ms.`
+        `[okffs] PR creation hit the push→POST indexing race (422) — retry ${attempt}/${attempts - 1} in ${delayMs}ms.`
       );
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }

--- a/src/github_errors.test.ts
+++ b/src/github_errors.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { summarizeGitHubError, isPrCreateRaceError } from "./github_errors.js";
+
+const apiError = (status: number, body: unknown) =>
+  new Error(`GitHub API error ${status}: ${JSON.stringify(body)}`);
+
+test("summarizeGitHubError extracts the top-level message", () => {
+  assert.equal(summarizeGitHubError(apiError(404, { message: "Not Found" })), "404 Not Found");
+});
+
+test("summarizeGitHubError appends 422 errors[] entry messages", () => {
+  const err = apiError(422, {
+    message: "Validation Failed",
+    errors: [{ resource: "PullRequest", code: "custom", message: "A pull request already exists for a:b." }],
+  });
+  assert.equal(
+    summarizeGitHubError(err),
+    "422 Validation Failed (A pull request already exists for a:b.)"
+  );
+});
+
+test("summarizeGitHubError renders resource.field.code when an entry has no message", () => {
+  const err = apiError(422, {
+    message: "Validation Failed",
+    errors: [{ resource: "PullRequest", field: "head", code: "invalid" }],
+  });
+  assert.equal(summarizeGitHubError(err), "422 Validation Failed (PullRequest.head.invalid)");
+});
+
+test("summarizeGitHubError joins multiple errors[] entries and accepts string entries", () => {
+  const err = apiError(422, {
+    message: "Validation Failed",
+    errors: ["first problem", { message: "second problem" }],
+  });
+  assert.equal(summarizeGitHubError(err), "422 Validation Failed (first problem; second problem)");
+});
+
+test("summarizeGitHubError ignores an empty or malformed errors[]", () => {
+  assert.equal(
+    summarizeGitHubError(apiError(422, { message: "Validation Failed", errors: [] })),
+    "422 Validation Failed"
+  );
+  assert.equal(
+    summarizeGitHubError(apiError(422, { message: "Validation Failed", errors: [{}, null, ""] })),
+    "422 Validation Failed"
+  );
+});
+
+test("summarizeGitHubError falls back to the raw string for unknown shapes", () => {
+  assert.equal(summarizeGitHubError(new Error("boom")), "boom");
+  assert.equal(summarizeGitHubError("plain string"), "plain string");
+  assert.equal(summarizeGitHubError(new Error("GitHub API error 500: not json")), "500 not json");
+});
+
+test("isPrCreateRaceError matches the classic 'no commits between' 422", () => {
+  assert.equal(
+    isPrCreateRaceError('GitHub API error 422: {"message":"No commits between develop and 1-x"}'),
+    true
+  );
+});
+
+test("isPrCreateRaceError matches a Validation Failed 422 with an invalid head field", () => {
+  const msg =
+    'GitHub API error 422: {"message":"Validation Failed","errors":[{"resource":"PullRequest","field":"head","code":"invalid"}]}';
+  assert.equal(isPrCreateRaceError(msg), true);
+});
+
+test("isPrCreateRaceError does NOT match permanent 422s or other statuses", () => {
+  const exists =
+    'GitHub API error 422: {"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists."}]}';
+  assert.equal(isPrCreateRaceError(exists), false);
+  assert.equal(isPrCreateRaceError("GitHub API error 404: not found"), false);
+  assert.equal(
+    isPrCreateRaceError('GitHub API error 403: {"message":"no commits between? nope"}'),
+    false
+  );
+});

--- a/src/github_errors.ts
+++ b/src/github_errors.ts
@@ -1,0 +1,62 @@
+// Pure helpers for interpreting GitHub API errors. Kept dependency-free (no
+// import of github.ts, which resolves token/repo at import time) so they can be
+// unit-tested without a configured environment (#271).
+
+/**
+ * Turn a thrown request() error ("GitHub API error 422: {json body}") into a
+ * concise, human message — "<status> <github message> (<detail>; …)" — by
+ * extracting GitHub's `message` field from the JSON body instead of dumping the
+ * whole raw response. For a 422 the top-level message is often just
+ * "Validation Failed" with the actual reason in the `errors[]` array, so each
+ * entry's `message` (or its `resource`/`field`/`code` triple when there's no
+ * message) is appended in parentheses (#247, #271). Falls back to the raw
+ * string when it doesn't match the known shape.
+ */
+export function summarizeGitHubError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const m = raw.match(/^GitHub (?:API|GraphQL) error (\d+): ([\s\S]*)$/);
+  if (!m) return raw;
+  const [, status, body] = m;
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed.message === "string" && parsed.message.trim()) {
+      const details = Array.isArray(parsed.errors)
+        ? parsed.errors
+            .map((e: unknown) => {
+              if (typeof e === "string") return e.trim();
+              if (e && typeof e === "object") {
+                const entry = e as { message?: unknown; resource?: unknown; field?: unknown; code?: unknown };
+                if (typeof entry.message === "string" && entry.message.trim()) return entry.message.trim();
+                const triple = [entry.resource, entry.field, entry.code].filter(
+                  (v): v is string => typeof v === "string" && v !== ""
+                );
+                if (triple.length) return triple.join(".");
+              }
+              return "";
+            })
+            .filter(Boolean)
+        : [];
+      const suffix = details.length ? ` (${details.join("; ")})` : "";
+      return `${status} ${parsed.message.trim()}${suffix}`;
+    }
+  } catch {
+    /* body isn't JSON — fall through to the trimmed raw form */
+  }
+  return `${status} ${body}`.trim();
+}
+
+/**
+ * Is this thrown-error message the push→POST indexing race behind #247 — a PR
+ * POST rejected 422 because GitHub hasn't finished indexing a commit pushed
+ * moments earlier? Two known presentations:
+ *  - "No commits between <base> and <head>" (the classic body), and
+ *  - a bare "Validation Failed" whose errors[] marks the `head` field invalid
+ *    (the just-pushed branch/sha isn't visible to the API yet) (#271).
+ * Other 422s (e.g. "A pull request already exists") are permanent and must NOT
+ * be retried, so this deliberately stays narrow rather than matching all 422s.
+ */
+export function isPrCreateRaceError(msg: string): boolean {
+  if (!/error 422/.test(msg)) return false;
+  if (/no commits between/i.test(msg)) return true;
+  return /"field":\s*"head"/.test(msg) && /"code":\s*"invalid"/.test(msg);
+}


### PR DESCRIPTION
## Summary
GitHub error summaries no longer drop the diagnosable detail: summarizeGitHubError appends a compact rendering of the 422 errors[] array (entry message, or resource.field.code) after the top-level message, so "422 Validation Failed" now says why. The auto-PR retry predicate is extracted to isPrCreateRaceError and widened to one additional known presentation of the push→POST indexing race — a Validation Failed 422 whose errors[] marks the head field invalid — while permanent 422s like "A pull request already exists" still fail immediately. Both helpers now live in a pure, dependency-free src/github_errors.ts (re-exported from github.ts) with 10 unit tests, since github.ts can't be imported in tests without a configured env.

## Changes
- chore: init branch for #271
- fix: surface 422 errors[] detail in summarizeGitHubError and widen the

## Issue comments

```
### 🔧 Commit update

**Commit:** `65e146d`
**Message:** fix: surface 422 errors[] detail in summarizeGitHubError and widen the
**Time:** 2026-08-11T05:17:27.740Z

**Files changed:**
- `src/github.ts`

**Summary:** fix: surface 422 errors[] detail in summarizeGitHubError and widen the auto-PR retry predicate

summarizeGitHubError now appends a compact rendering of the errors[] array (each entry's message, or resource.field.code) after the top-level message, so a bare "422 Validation Failed" carries its actual reason. The PR-create retry predicate moves to an exported isPrCreateRaceError that also treats a Validation Failed 422 with an invalid `head` field as the push→POST indexing race — while permanent 422s (e.g. "A pull request already exists") still fail fast. Both helpers extracted to a pure, import-safe github_errors.ts with unit tests.

```


Closes #271