### PR TITLE
Fix into develop: 269-fragment-recategorize

### DIFF
--- a/.changes/unreleased/269-commit-and-update-is-not-idempotent.md
+++ b/.changes/unreleased/269-commit-and-update-is-not-idempotent.md
@@ -1,2 +1,2 @@
-<!-- okffs:type=Changed -->
-- commit_and_update is not idempotent on retry — clean-tree "nothing to commit" reported as failure ([#269](https://github.com/neturely/okffs/issues/269))
+<!-- okffs:type=Fixed -->
+- commit_and_update no longer reports a false failure on retry — a clean tree whose HEAD already matches the remote tip is treated as an idempotent success ([#269](https://github.com/neturely/okffs/issues/269))


### PR DESCRIPTION
Recategorize the #269 changelog fragment from Changed to Fixed and reword it as the fix (not the bug) — caught while previewing the 0.10.2 release, where it would have rolled into the wrong CHANGELOG section.

## Landing (1 commit)
- docs: recategorize #269 changelog fragment as Fixed with a clearer line