### PR TITLE
Fix into develop: 278-fold-into-0.10.2

### DIFF
--- a/.changes/unreleased/278-update-project-status-rename-issue-param.md
+++ b/.changes/unreleased/278-update-project-status-rename-issue-param.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- update_project_status: rename `issue` param to `issue_number` for cross-tool consistency ([#278](https://github.com/neturely/okffs/issues/278))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ## [0.10.2] - 2026-08-11
+### Changed
+- update_project_status: rename `issue` param to `issue_number` for cross-tool consistency (`issue` stays as a deprecated alias for one release) ([#278](https://github.com/neturely/okffs/issues/278))
+
 ### Fixed
 - Stale owner after repo transfer: head= filter silently matches nothing — canonicalize owner/repo at startup + name the… ([#273](https://github.com/neturely/okffs/issues/273))
 - summarizeGitHubError drops the 422 errors[] detail; auto-PR retry predicate misses "Validation Failed" 422s ([#271](https://github.com/neturely/okffs/issues/271))


### PR DESCRIPTION
Fold #278's changelog fragment into the already-rolled 0.10.2 section — the release roll (#276) happened before #278 merged, so its entry was sitting as an unreleased fragment; this moves it under `## [0.10.2] ### Changed` and deletes the fragment so 0.10.2's notes are complete.

## Landing (1 commit)
- docs: fold #278 changelog entry into the 0.10.2 section