### PR TITLE
Fix into develop: 277-review-fixes

### DIFF
--- a/src/tools/commit_and_update.ts
+++ b/src/tools/commit_and_update.ts
@@ -62,6 +62,18 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   const issue = await getIssue(input.issue_number);
   const branchName = extractBranchFromBody(issue.body);
 
+  // Without a **Branch:** line there is no issue branch to commit to — carrying
+  // on would commit onto whatever branch happens to be checked out and never
+  // push. Refuse early instead (PR #277 review).
+  if (!branchName) {
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Issue #${input.issue_number} has no associated branch (no **Branch:** line), so there's nothing to commit to. Use create_pull_request with an explicit \`branch\` to backfill the link, or add the **Branch:** line to the issue body.`,
+      }],
+    };
+  }
+
   // Files changed relative to HEAD — used for the commit message and comment.
   let changedFiles: string[] = [];
   try {
@@ -88,6 +100,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
   const previousBranch = currentBranch();
   let commitHash = "";
   let idempotentRetry = false;
+  let retrySubject = "";
   try {
     if (branchName && previousBranch !== branchName) {
       git(["checkout", branchName]);
@@ -102,18 +115,21 @@ export async function handler(input: z.infer<typeof inputSchema>) {
     // on the remote → keep a friendly error (nothing was committed or pushed).
     if (gitOutput(["status", "--porcelain"]) === "") {
       const head = gitOutput(["rev-parse", "HEAD"]);
-      const remoteRef = branchName
-        ? gitOutput(["ls-remote", "origin", `refs/heads/${branchName}`])
-        : "";
+      const remoteRef = gitOutput(["ls-remote", "origin", `refs/heads/${branchName}`]);
       const remoteTip = remoteRef.split(/\s+/)[0] ?? "";
       if (remoteTip && remoteTip === head) {
         idempotentRetry = true;
         commitHash = gitOutput(["rev-parse", "--short", "HEAD"]);
+        // Capture the landed commit's subject here, keyed by the full hash and
+        // while still on the issue branch — a short hash can turn ambiguous as
+        // history grows, and after `finally` we're back on the caller's branch
+        // (PR #277 review).
+        retrySubject = gitOutput(["log", "-1", "--pretty=%s", head]);
       } else {
         return {
           content: [{
             type: "text" as const,
-            text: `Nothing to commit: the working tree is clean and the latest commit is not on \`origin/${branchName ?? "?"}\`. Make some changes first (or push the branch manually if that was the intent).`,
+            text: `Nothing to commit: the working tree is clean and the latest commit is not on \`origin/${branchName}\`. Make some changes first (or push the branch manually if that was the intent).`,
           }],
         };
       }
@@ -157,9 +173,7 @@ export async function handler(input: z.infer<typeof inputSchema>) {
 
   // On an idempotent retry nothing was committed this call — report the subject
   // of the commit that actually landed rather than the rebuilt (unused) message.
-  const reportedMessage = idempotentRetry
-    ? gitOutput(["log", "-1", "--pretty=%s", commitHash])
-    : commitMessage;
+  const reportedMessage = idempotentRetry ? retrySubject : commitMessage;
 
   const comment = [
     `### 🔧 Commit update${idempotentRetry ? " (idempotent retry — already committed and pushed)" : ""}`,


### PR DESCRIPTION
Address Copilot review on the 0.10.2 promotion PR (#277): (1) commit_and_update now refuses early when the issue has no **Branch:** line — previously it would commit onto whatever branch was checked out and never push; the message mirrors merge_pull_request's and points at create_pull_request's branch backfill. (2) On the idempotent-retry path, the landed commit's subject is captured inside the try block, keyed by the full hash while still on the issue branch — a short hash can become ambiguous over time, and the previous lookup also ran after the caller's branch was restored.

## Landing (1 commit)
- fix: address PR #277 review — refuse commit_and_update without a Branch: line; look up the retry subject by full hash on-branch