### PR TITLE
Fix into develop: fix/0.11.0-changelog-fragments

### DIFF
--- a/.changes/unreleased/265-commit-and-update-silent-add-all.md
+++ b/.changes/unreleased/265-commit-and-update-silent-add-all.md
@@ -1,2 +1,2 @@
-<!-- okffs:type=Added -->
-- commit_and_update: silent add-all staging and discarded commit messages enabled a secrets leak ([#265](https://github.com/neturely/okffs/issues/265))
+<!-- okffs:type=Security -->
+- `commit_and_update` no longer silently sweeps untracked files into commits: staging defaults to tracked-modified only (`git add -u`), untracked files require `include_untracked: true`, a secrets deny-list (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `*credentials*`, `*.p12`, `*.pfx`) refuses secret-looking filenames unless overridden, the caller's `hint` is used verbatim as the commit message, and the tool result lists every staged file untruncated with per-file +/- counts ([#265](https://github.com/neturely/okffs/issues/265))

--- a/.changes/unreleased/267-upsert-issue-comments-by-marker-edit.md
+++ b/.changes/unreleased/267-upsert-issue-comments-by-marker-edit.md
@@ -1,2 +1,2 @@
 <!-- okffs:type=Added -->
-- Upsert issue comments by marker (edit-or-create), not just append ([#267](https://github.com/neturely/okffs/issues/267))
+- `comment_issue` can upsert: pass a `marker` to edit the existing comment carrying that hidden marker in place (or create it), enabling a single running status comment per issue instead of an append-only thread ([#267](https://github.com/neturely/okffs/issues/267))

--- a/.changes/unreleased/282-create-issue-takes-description-but-update.md
+++ b/.changes/unreleased/282-create-issue-takes-description-but-update.md
@@ -1,2 +1,2 @@
-<!-- okffs:type=Added -->
-- create_issue takes `description` but update_issue takes `body` — unify the param name for the issue body ([#282](https://github.com/neturely/okffs/issues/282))
+<!-- okffs:type=Changed -->
+- `body` is now the canonical issue-body param across `create_issue`, `plan`, and `create_issues_from_list` (matching `update_issue` and GitHub's own field); `description` remains as a deprecated alias for one release — using it warns, passing both errors ([#282](https://github.com/neturely/okffs/issues/282))

--- a/.changes/unreleased/284-commit-and-update-comment-step-failure.md
+++ b/.changes/unreleased/284-commit-and-update-comment-step-failure.md
@@ -1,2 +1,2 @@
 <!-- okffs:type=Fixed -->
-- commit_and_update: comment-step failure after successful commit+push escapes as raw 'MCP error -32603: fetch failed' ([#284](https://github.com/neturely/okffs/issues/284))
+- `commit_and_update` no longer surfaces a raw `MCP error -32603: fetch failed`: an issue-lookup failure returns a contextual error, a comment-post failure after the durable commit+push returns success-with-warning carrying the commit hash and branch, and all GitHub fetches now carry a 30s timeout (GETs retried once; writes never) ([#284](https://github.com/neturely/okffs/issues/284))


### PR DESCRIPTION
Recategorizes and clarifies the four 0.11.0 changelog fragments before the release roll: the lines were raw issue titles (problem descriptions) under the wrong headings — #265 moves to Security, #282 to Changed, and all four are rewritten as user-facing change descriptions.

## Landing (1 commit)
- docs: recategorize and clarify the 0.11.0 changelog fragments