### PR TITLE
Release 0.11.0

### DIFF
--- a/.changes/unreleased/265-commit-and-update-silent-add-all.md
+++ b/.changes/unreleased/265-commit-and-update-silent-add-all.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Security -->
-- `commit_and_update` no longer silently sweeps untracked files into commits: staging defaults to tracked-modified only (`git add -u`), untracked files require `include_untracked: true`, a secrets deny-list (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `*credentials*`, `*.p12`, `*.pfx`) refuses secret-looking filenames unless overridden, the caller's `hint` is used verbatim as the commit message, and the tool result lists every staged file untruncated with per-file +/- counts ([#265](https://github.com/neturely/okffs/issues/265))

--- a/.changes/unreleased/267-upsert-issue-comments-by-marker-edit.md
+++ b/.changes/unreleased/267-upsert-issue-comments-by-marker-edit.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Added -->
-- `comment_issue` can upsert: pass a `marker` to edit the existing comment carrying that hidden marker in place (or create it), enabling a single running status comment per issue instead of an append-only thread ([#267](https://github.com/neturely/okffs/issues/267))

--- a/.changes/unreleased/282-create-issue-takes-description-but-update.md
+++ b/.changes/unreleased/282-create-issue-takes-description-but-update.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Changed -->
-- `body` is now the canonical issue-body param across `create_issue`, `plan`, and `create_issues_from_list` (matching `update_issue` and GitHub's own field); `description` remains as a deprecated alias for one release — using it warns, passing both errors ([#282](https://github.com/neturely/okffs/issues/282))

--- a/.changes/unreleased/284-commit-and-update-comment-step-failure.md
+++ b/.changes/unreleased/284-commit-and-update-comment-step-failure.md
@@ -1,2 +1,0 @@
-<!-- okffs:type=Fixed -->
-- `commit_and_update` no longer surfaces a raw `MCP error -32603: fetch failed`: an issue-lookup failure returns a contextual error, a comment-post failure after the durable commit+push returns success-with-warning carrying the commit hash and branch, and all GitHub fetches now carry a 30s timeout (GETs retried once; writes never) ([#284](https://github.com/neturely/okffs/issues/284))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-12
+### Security
+- `commit_and_update` no longer silently sweeps untracked files into commits: staging defaults to tracked-modified only (`git add -u`), untracked files require `include_untracked: true`, a secrets deny-list (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `*credentials*`, `*.p12`, `*.pfx`) refuses secret-looking filenames unless overridden, the caller's `hint` is used verbatim as the commit message, and the tool result lists every staged file untruncated with per-file +/- counts ([#265](https://github.com/neturely/okffs/issues/265))
+### Added
+- `comment_issue` can upsert: pass a `marker` to edit the existing comment carrying that hidden marker in place (or create it), enabling a single running status comment per issue instead of an append-only thread ([#267](https://github.com/neturely/okffs/issues/267))
+### Changed
+- `body` is now the canonical issue-body param across `create_issue`, `plan`, and `create_issues_from_list` (matching `update_issue` and GitHub's own field); `description` remains as a deprecated alias for one release — using it warns, passing both errors ([#282](https://github.com/neturely/okffs/issues/282))
+### Fixed
+- `commit_and_update` no longer surfaces a raw `MCP error -32603: fetch failed`: an issue-lookup failure returns a contextual error, a comment-post failure after the durable commit+push returns success-with-warning carrying the commit hash and branch, and all GitHub fetches now carry a 30s timeout (GETs retried once; writes never) ([#284](https://github.com/neturely/okffs/issues/284))
+
 ## [0.10.2] - 2026-08-11
 ### Changed
 - update_project_status: rename `issue` param to `issue_number` for cross-tool consistency (`issue` stays as a deprecated alias for one release) ([#278](https://github.com/neturely/okffs/issues/278))
@@ -173,7 +183,8 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `create_pull_request` commits the updated CHANGELOG onto the branch and pushes the branch before opening the PR, with non-blocking error handling ([#38](https://github.com/2b9sa2owa/okffs/issues/38)).
 - All git operations now run via `execFileSync` with argument arrays (no shell), removing command-injection risk from branch names and commit hints; tools also checkout the target branch before committing/pushing and restore the original branch afterward.
 
-[Unreleased]: https://github.com/neturely/okffs/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/neturely/okffs/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/neturely/okffs/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/neturely/okffs/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/neturely/okffs/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/neturely/okffs/compare/v0.9.0...v0.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neturely/okffs",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neturely/okffs",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "mcpName": "io.github.neturely/okffs",
   "description": "MCP server that connects Claude Code to GitHub — create and manage issues and branches without leaving your editor.",
   "type": "module",


### PR DESCRIPTION
## Release 0.11.0

- Bumped `package.json` and `package-lock.json` to 0.11.0.
- Rolled the CHANGELOG `[Unreleased]` section into `## [0.11.0]` and refreshed the compare links.
- Assembled and removed 4 changelog fragment(s) from `.changes/unreleased/`.

After merging, tag `v0.11.0` and push it — CI (`publish.yml`) publishes to npm on the tag. This PR does not tag or publish.