### PR TITLE
Fix into develop: fix-300-schema-required-params

### DIFF
--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -79,8 +79,9 @@ export const inputSchema = z.object({
   title: z.string().describe("Issue title"),
   // `body` is the canonical name (#282), matching update_issue and GitHub's own
   // field. The `description` alias shipped in 0.11.0 as a one-release
-  // deprecation and was removed in #297.
-  body: z.string().optional().describe("Issue body"),
+  // deprecation and was removed in #297; required in the schema so a missing
+  // body fails validation up front rather than at runtime (PR #300 review).
+  body: z.string().describe("Issue body"),
   assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
   labels: z.array(z.string()).optional().describe("Labels to apply e.g. bug, feature"),
   milestone: z.number().int().optional().describe("Milestone number to assign"),

--- a/src/tools/create_issues_from_list.ts
+++ b/src/tools/create_issues_from_list.ts
@@ -21,8 +21,9 @@ export const description =
 const taskSchema = z.object({
   title: z.string().describe("Issue title"),
   // `body` is the canonical name (#282); the `description` alias was removed
-  // in #297.
-  body: z.string().optional().describe("Issue body"),
+  // in #297, and `body` is required in the schema so a missing one fails
+  // validation up front (PR #300 review).
+  body: z.string().describe("Issue body"),
   assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
   labels: z.array(z.string()).optional().describe("Labels to apply to this issue"),
   milestone: z.number().int().optional().describe("Milestone number to assign"),

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -44,9 +44,11 @@ const relationshipSchema = z.object({
 const taskSchema = z.object({
   title: z.string().describe("Issue title"),
   // `body` is the canonical name (#282); the per-task `description` alias was
-  // removed in #297. Note the top-level `description` input (the free-text work
-  // description) is a different field and is unaffected.
-  body: z.string().optional().describe("Issue body"),
+  // removed in #297, and `body` is required in the schema so a missing one
+  // fails validation up front (PR #300 review). Note the top-level
+  // `description` input (the free-text work description) is a different field
+  // and is unaffected.
+  body: z.string().describe("Issue body"),
   assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
   labels: z.array(z.string()).optional().describe("Labels to apply to this issue"),
   milestone: z.number().int().optional().describe("Milestone number to assign"),

--- a/src/tools/update_project_status.ts
+++ b/src/tools/update_project_status.ts
@@ -16,8 +16,9 @@ const STATUSES = ["Backlog", "Ready", "In Progress", "Review"] as const;
 export const inputSchema = z.object({
   // `issue_number` is the canonical name, matching every other issue-taking
   // tool (#278). The `issue` alias shipped in 0.11.0 as a one-release
-  // deprecation and was removed in #297.
-  issue_number: z.number().int().positive().optional().describe("Issue number to move"),
+  // deprecation and was removed in #297; required in the schema so a missing
+  // issue number fails validation up front (PR #300 review).
+  issue_number: z.number().int().positive().describe("Issue number to move"),
   status: z
     .enum(STATUSES)
     .describe('Target column: "Backlog", "Ready", "In Progress", or "Review" (Done is owned by native automation)'),
@@ -27,9 +28,6 @@ const text = (t: string) => ({ content: [{ type: "text" as const, text: t }] });
 
 export async function handler(input: z.infer<typeof inputSchema>) {
   const issueNumber = input.issue_number;
-  if (!issueNumber) {
-    return text("[okffs] update_project_status needs an issue_number (which issue to move). (The old `issue` param was removed in 0.12.0.)");
-  }
 
   if (!config.projectEnabled) {
     return text("OKFFS_PROJECT_ENABLED is not set — project status updates are disabled.");


### PR DESCRIPTION
Addresses the 4 Copilot review comments on promotion PR #300: the #297 alias removal left `body` (create_issue, and the task objects of plan / create_issues_from_list) and `issue_number` (update_project_status) marked optional in the Zod schemas while the handlers treat them as required. They are now required in the schemas, so hosts see the real contract and a missing param fails validation up front instead of at runtime. Suite 70/70, typecheck clean.

## Landing (1 commit)
- fix: make body / issue_number required in the tool schemas to match runtime behavior (PR #300 Copilot review)